### PR TITLE
added ability to pass multiple dirs to the --path option

### DIFF
--- a/ward/collect.py
+++ b/ward/collect.py
@@ -13,22 +13,28 @@ def is_test_module(module: pkgutil.ModuleInfo) -> bool:
     return module.name.startswith("test_")
 
 
-def get_info_for_modules(path: List[str]) -> Generator[pkgutil.ModuleInfo, None, None]:
+def get_info_for_modules(paths: List[str]) -> Generator[pkgutil.ModuleInfo, None, None]:
     # If multiple paths are specified, remove duplicates
-    paths = list(set(path))
+    paths = list(set(paths))
     
     # Check for modules at the root of the specified path (or paths)
     for module in pkgutil.iter_modules(paths):
         yield module
+
+    # make sure we are not rechecking directories
+    checked_dirs = paths.copy()
 
     # Now check for modules in every subdirectory
     for p in paths:
         for root, dirs, _ in os.walk(p):
             for dir_name in dirs:
                 dir_path = os.path.join(root, dir_name)
-                for module in pkgutil.iter_modules([dir_path]):
-                    if is_test_module(module):
-                        yield module
+                # if we have seen this directory before, skip it
+                if dir_path not in checked_dirs:
+                    checked_dirs.append(dir_path)
+                    for module in pkgutil.iter_modules([dir_path]):
+                        if is_test_module(module):
+                            yield module
 
 
 def load_modules(modules: Iterable[pkgutil.ModuleInfo]) -> Generator[Any, None, None]:

--- a/ward/run.py
+++ b/ward/run.py
@@ -19,8 +19,7 @@ if platform.system() == "Windows":
 
 
 @click.command()
-@click.option("-p", "--path", nargs=0, default=".", type=click.Path(exists=True), help="Path to tests.")
-@click.argument('path', nargs=-1)
+@click.option("-p", "--path", default=".", type=click.Path(exists=True), help="Path to tests.", multiple=True)
 @click.option("-f", "--filter", help="Only run tests whose names contain the filter argument as a substring.")
 @click.option("--fail-limit", type=int, help="The number of failures to cancel the run after.")
 def run(path, filter, fail_limit):

--- a/ward/run.py
+++ b/ward/run.py
@@ -19,7 +19,8 @@ if platform.system() == "Windows":
 
 
 @click.command()
-@click.option("-p", "--path", default=".", type=click.Path(exists=True), help="Path to tests.")
+@click.option("-p", "--path", nargs=0, default=".", type=click.Path(exists=True), help="Path to tests.")
+@click.argument('path', nargs=-1)
 @click.option("-f", "--filter", help="Only run tests whose names contain the filter argument as a substring.")
 @click.option("--fail-limit", type=int, help="The number of failures to cancel the run after.")
 def run(path, filter, fail_limit):


### PR DESCRIPTION
resolves #37 

Updated the click argument for run to accept any number of directories. I noticed while testing that it is possible to supply 0 arguments which may not be desired. Unfortunately, the click library does not have a simple way of accepting a variable number of args and so I had to use a workaround (see run.py).

Updated collect.py to handle a list of directories as well.