### PR TITLE
Initial implentation of output capturing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project is a work in progress. Some of the features that are currently avai
 * Highly readable, colourful diffs intended to be as readable as possible
 * A human readable assertion API
 * Tested on Mac OS, Linux, and Windows
+* stderr/stdout captured during test and fixture execution
 
 Planned features:
 
@@ -23,7 +24,6 @@ Planned features:
 * Code coverage with `--coverage` flag
 * Handling flaky tests with test-specific retries, timeouts
 * Integration with unittest.mock (specifics to be ironed out)
-* Capturing of stderr/stdout
 * Plugin system
 * Highlighting diffs on a per-character basis, similar to [diff-so-fancy](https://github.com/so-fancy/diff-so-fancy) (right now it's just per line)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-version = "0.7.0a0"
+version = "0.8.0a0"
 
 setup(
     name="ward",

--- a/ward/suite.py
+++ b/ward/suite.py
@@ -1,3 +1,5 @@
+import io
+from contextlib import suppress, redirect_stdout, redirect_stderr
 from dataclasses import dataclass
 from typing import Generator, List
 
@@ -22,37 +24,47 @@ class Suite:
     def generate_test_runs(self) -> Generator[TestResult, None, None]:
         for test in self.tests:
             if test.marker == WardMarker.SKIP:
-                yield TestResult(test, TestOutcome.SKIP, None, "")
+                yield TestResult(test, TestOutcome.SKIP)
                 continue
 
+            sout, serr = io.StringIO(), io.StringIO()
             try:
-                resolved_fixtures = test.resolve_args(self.fixture_registry)
+                with redirect_stdout(sout), redirect_stderr(serr):
+                    resolved_fixtures = test.resolve_args(self.fixture_registry)
             except FixtureExecutionError as e:
-                yield TestResult(test, TestOutcome.FAIL, e)
+                yield TestResult(
+                    test, TestOutcome.FAIL, e, captured_stdout=sout.getvalue(), captured_stderr=serr.getvalue()
+                )
+                sout.close()
+                serr.close()
                 continue
             try:
                 resolved_vals = {k: fix.resolved_val for (k, fix) in resolved_fixtures.items()}
 
-                # Run the test
-                test(**resolved_vals)
+                # Run the test, while capturing output.
+                with redirect_stdout(sout), redirect_stderr(serr):
+                    test(**resolved_vals)
 
                 # The test has completed without exception and therefore passed
                 if test.marker == WardMarker.XFAIL:
-                    yield TestResult(test, TestOutcome.XPASS, None)
+                    yield TestResult(
+                        test, TestOutcome.XPASS, captured_stdout=sout.getvalue(), captured_stderr=serr.getvalue()
+                    )
                 else:
-                    yield TestResult(test, TestOutcome.PASS, None)
+                    yield TestResult(test, TestOutcome.PASS)
 
             except Exception as e:
                 if test.marker == WardMarker.XFAIL:
                     yield TestResult(test, TestOutcome.XFAIL, e)
                 else:
-                    yield TestResult(test, TestOutcome.FAIL, e)
+                    yield TestResult(
+                        test, TestOutcome.FAIL, e, captured_stdout=sout.getvalue(), captured_stderr=serr.getvalue()
+                    )
             finally:
                 for fixture in resolved_fixtures.values():
                     if fixture.is_generator_fixture:
-                        try:
+                        with suppress(RuntimeError, StopIteration):
                             fixture.cleanup()
-                        except (RuntimeError, StopIteration):
-                            # In Python 3.7, a RuntimeError is raised if we fall off the end of a generator
-                            # (instead of a StopIteration)
-                            pass
+
+                sout.close()
+                serr.close()

--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Generator, List, Optional, Dict
 
 from colorama import Fore, Style
-from termcolor import colored, cprint
+from termcolor import colored
 
 from ward.diff import build_auto_diff
 from ward.expect import ExpectationFailed

--- a/ward/test_result.py
+++ b/ward/test_result.py
@@ -19,3 +19,5 @@ class TestResult:
     outcome: TestOutcome
     error: Optional[Exception] = None
     message: str = ""
+    captured_stdout: str = ""
+    captured_stderr: str = ""


### PR DESCRIPTION
Output from stderr and stdout will be captured during test execution (and execution of corresponding fixtures), and it will be displayed should a test fail.

![Screenshot 2019-10-18 at 17 59 42](https://user-images.githubusercontent.com/5740731/67113325-1c7e2a00-f1d1-11e9-9ae4-681f77afac12.png)
