### PR TITLE
Rewrite fixture caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,11 @@ jobs:
     name: Testing on Python ${{ matrix.python-version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 6
+      max-parallel: 9
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -7,11 +7,11 @@ jobs:
     name: Testing on Python ${{ matrix.python-version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 6
+      max-parallel: 9
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from tests.test_suite import testable_test, FORCE_TEST_PATH
+from tests.test_suite import testable_test
 from ward import expect, fixture, test, Scope
 from ward.fixtures import Fixture, FixtureCache
 from ward.testing import Test
@@ -102,7 +102,7 @@ def _(
     cache: FixtureCache = cache,
     module_fixture=module_fixture,
 ):
-    fixtures_at_scope = cache.get_fixtures_at_scope(Scope.Module, FORCE_TEST_PATH)
+    fixtures_at_scope = cache.get_fixtures_at_scope(Scope.Module, testable_test.path)
 
     fixture = list(fixtures_at_scope.values())[0]
 
@@ -134,6 +134,7 @@ def _(
 
     expect(fixtures_at_scope).equals({})
 
+
 @test("FixtureCache.teardown_fixtures_for_scope runs teardown for Test fixtures")
 def _(
     cache: FixtureCache = cache,
@@ -149,9 +150,9 @@ def _(
 def _(
     cache: FixtureCache = cache,
 ):
-    cache.teardown_fixtures_for_scope(Scope.Module, FORCE_TEST_PATH)
+    cache.teardown_fixtures_for_scope(Scope.Module, testable_test.path)
 
-    fixtures_at_scope = cache.get_fixtures_at_scope(Scope.Module, FORCE_TEST_PATH)
+    fixtures_at_scope = cache.get_fixtures_at_scope(Scope.Module, testable_test.path)
 
     expect(fixtures_at_scope).equals({})
 
@@ -161,7 +162,7 @@ def _(
     cache: FixtureCache = cache,
     events: List = recorded_events,
 ):
-    cache.teardown_fixtures_for_scope(Scope.Module, FORCE_TEST_PATH)
+    cache.teardown_fixtures_for_scope(Scope.Module, testable_test.path)
 
     expect(events).equals(["teardown m"])
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,18 +1,19 @@
-from ward import expect, fixture, test
+from ward import expect, fixture, test, Scope
 from ward.fixtures import Fixture, FixtureCache
 
 
 @fixture
 def exception_raising_fixture():
+    @fixture
     def i_raise_an_exception():
         raise ZeroDivisionError()
 
     return Fixture(fn=i_raise_an_exception)
 
 
-@test("FixtureCache.cache_fixture can store and retrieve a single fixture")
+@test("FixtureCache.cache_fixture caches a single fixture")
 def _(f=exception_raising_fixture):
     cache = FixtureCache()
-    cache.cache_fixture(f)
+    cache.cache_fixture(f, "test_id")
 
-    expect(cache[f.key]).equals(f)
+    expect(cache.get(f.key, Scope.Test, "test_id")).equals(f)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -239,6 +239,12 @@ def _():
     def test3(a=a):
         events.append("test3")
 
+    # For testing purposes we need to assign paths ourselves,
+    # since our test functions are all defined at the same path
+    test1.ward_meta.path = "module1"
+    test2.ward_meta.path = "module2"
+    test3.ward_meta.path = "module2"
+
     suite = Suite(
         tests=[
             Test(fn=test1, module_name="module1"),
@@ -260,7 +266,6 @@ def _():
             "teardown",  # Teardown at end of module2
         ]
     )
-    expect(len(suite.cache)).equals(0)
 
 
 @test("Suite.generate_test_runs resolves and tears down global fixtures once only")
@@ -340,6 +345,10 @@ def _():
     def test_3(a=a, b=b, c=c):
         events.append("test3")
 
+    test_1.ward_meta.path = "module1"
+    test_2.ward_meta.path = "module2"
+    test_3.ward_meta.path = "module2"
+
     suite = Suite(
         tests=[
             Test(fn=test_1, module_name="module1"),
@@ -365,11 +374,10 @@ def _():
             "resolve c",  # test fixture resolved at start of test3
             "test3",
             "teardown c",  # test fixture teardown at end of test3
-            "teardown a",  # global fixtures are torn down at the very end
             "teardown b",  # module fixture teardown at end of module2
+            "teardown a",  # global fixtures are torn down at the very end
         ]
     )
-    expect(len(suite.cache)).equals(0)
 
 
 @skip("WIP")

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -285,7 +285,6 @@ def _():
             "teardown",  # Teardown only at end of run
         ]
     )
-    expect(len(suite.cache)).equals(0)  # Teardown includes cache cleanup
 
 
 @test("Suite.generate_test_runs resolves mixed scope fixtures correctly")

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -8,10 +8,15 @@ from ward.suite import Suite
 from ward.testing import Test, skip, TestOutcome, TestResult, test
 
 NUMBER_OF_TESTS = 5
+FORCE_TEST_PATH = "path/of/test"
 
 
 def testable_test(func):
-    return test("blah", _collect_into=defaultdict(list))(func)
+    return test(
+        "testable test description",
+        _force_path=FORCE_TEST_PATH,
+        _collect_into=defaultdict(list)
+    )(func)
 
 
 @fixture

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1,12 +1,17 @@
+from collections import defaultdict
 from unittest import mock
 
 from ward import expect, fixture
 from ward.fixtures import Fixture
 from ward.models import Scope, SkipMarker
 from ward.suite import Suite
-from ward.testing import Test, skip, test, TestOutcome, TestResult
+from ward.testing import Test, skip, TestOutcome, TestResult, test
 
 NUMBER_OF_TESTS = 5
+
+
+def testable_test(func):
+    return test("blah", _collect_into=defaultdict(list))(func)
 
 
 @fixture
@@ -41,6 +46,7 @@ def example_test(module=module, fixtures=fixtures):
     def f():
         return 123
 
+    @testable_test
     def t(fix_a=f):
         return fix_a
 
@@ -49,7 +55,11 @@ def example_test(module=module, fixtures=fixtures):
 
 @fixture
 def skipped_test(module=module):
-    return Test(fn=lambda: expect(1).equals(1), module_name=module, marker=SkipMarker())
+    @testable_test
+    def t():
+        expect(1).equals(1)
+
+    return Test(fn=t, module_name=module, marker=SkipMarker())
 
 
 @fixture
@@ -85,19 +95,19 @@ def _(suite=suite):
 
 @test("Suite.generate_test_runs yields a FAIL TestResult on `assert False`")
 def _(module=module):
-    def test_i_fail():
+    @testable_test
+    def _():
         assert False
 
-    test = Test(fn=test_i_fail, module_name=module)
-    failing_suite = Suite(tests=[test])
+    t = Test(fn=_, module_name=module)
+    failing_suite = Suite(tests=[t])
 
     results = failing_suite.generate_test_runs()
     result = next(results)
 
     expected_result = TestResult(
-        test=test, outcome=TestOutcome.FAIL, error=mock.ANY, message=""
+        test=t, outcome=TestOutcome.FAIL, error=mock.ANY, message=""
     )
-
     expect(result).equals(expected_result)
     expect(result.error).instance_of(AssertionError)
 
@@ -132,6 +142,7 @@ def _(module=module):
         events.append(2)
         return "b"
 
+    @testable_test
     def my_test(fix_a=fix_a, fix_b=fix_b):
         expect(fix_a).equals("a")
         expect(fix_b).equals("b")
@@ -165,6 +176,7 @@ def _(module=module):
         yield "c"
         events.append(5)
 
+    @testable_test
     def my_test(fix_a=fix_a, fix_c=fix_c):
         expect(fix_a).equals("a")
         expect(fix_c).equals("c")
@@ -194,6 +206,7 @@ def _(module=module):
     def c(a=a):
         events.append(3)
 
+    @testable_test
     def test(b=b, c=c):
         pass
 
@@ -214,12 +227,15 @@ def _():
         yield "a"
         events.append("teardown")
 
+    @testable_test
     def test1(a=a):
         events.append("test1")
 
+    @testable_test
     def test2(a=a):
         events.append("test2")
 
+    @testable_test
     def test3(a=a):
         events.append("test3")
 
@@ -257,12 +273,15 @@ def _():
         yield "a"
         events.append("teardown")
 
+    @testable_test
     def test1(a=a):
         events.append("test1")
 
+    @testable_test
     def test2(a=a):
         events.append("test2")
 
+    @testable_test
     def test3(a=a):
         events.append("test3")
 
@@ -309,26 +328,28 @@ def _():
         yield "c"
         events.append("teardown c")
 
-    def test1(a=a, b=b, c=c):
+    @testable_test
+    def test_1(a=a, b=b, c=c):
         events.append("test1")
 
-    def test2(a=a, b=b, c=c):
+    @testable_test
+    def test_2(a=a, b=b, c=c):
         events.append("test2")
 
-    def test3(a=a, b=b, c=c):
+    @testable_test
+    def test_3(a=a, b=b, c=c):
         events.append("test3")
 
     suite = Suite(
         tests=[
-            Test(fn=test1, module_name="module1"),
-            Test(fn=test2, module_name="module2"),
-            Test(fn=test3, module_name="module2"),
+            Test(fn=test_1, module_name="module1"),
+            Test(fn=test_2, module_name="module2"),
+            Test(fn=test_3, module_name="module2"),
         ]
     )
 
     list(suite.generate_test_runs())
 
-    # Note that the ordering of the final teardowns aren't well-defined
     expect(events).equals(
         [
             "resolve a",  # global fixture so resolved at start

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -18,6 +18,8 @@ def testable_test(func):
         _collect_into=defaultdict(list)
     )(func)
 
+testable_test.path = FORCE_TEST_PATH
+
 
 @fixture
 def module():

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,7 +1,8 @@
 from unittest import mock
 from unittest.mock import Mock
 
-from ward import expect, raises
+from tests.test_suite import testable_test
+from ward import expect, raises, Scope
 from ward.errors import ParameterisationError
 from ward.fixtures import fixture
 from ward.testing import Test, test, each, ParamMeta
@@ -17,6 +18,7 @@ t = Test(fn=f, module_name=mod)
 
 @fixture
 def anonymous_test():
+    @testable_test
     def _():
         expect(1).equals(1)
 
@@ -98,6 +100,27 @@ def _():
     expect(t.is_parameterised).equals(False)
 
 
+@test("Test.scope_key_from(Scope.Test) returns the test ID")
+def _(t: Test = anonymous_test):
+    scope_key = t.scope_key_from(Scope.Test)
+
+    expect(scope_key).equals(t.id)
+
+
+@test("Test.scope_key_from(Scope.Module) returns the path of the test module")
+def _(t: Test = anonymous_test):
+    scope_key = t.scope_key_from(Scope.Module)
+
+    expect(scope_key).equals(testable_test.path)
+
+
+@test("Test.scope_key_from(Scope.Global) returns Scope.Global")
+def _(t: Test = anonymous_test):
+    scope_key = t.scope_key_from(Scope.Global)
+
+    expect(scope_key).equals(Scope.Global)
+
+
 @test("Test.get_parameterised_instances returns test in list if not parameterised")
 def _():
     def test():
@@ -144,4 +167,4 @@ def _():
     t = Test(fn=invalid_test, module_name=mod)
 
     with raises(ParameterisationError):
-        a = t.get_parameterised_instances()
+        t.get_parameterised_instances()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -121,7 +121,7 @@ def _(t: Test = anonymous_test):
     expect(scope_key).equals(Scope.Global)
 
 
-@test("Test.get_parameterised_instances returns test in list if not parameterised")
+@test("Test.get_parameterised_instances returns [self] if not parameterised")
 def _():
     def test():
         pass

--- a/ward/collect.py
+++ b/ward/collect.py
@@ -7,8 +7,8 @@ from importlib._bootstrap import ModuleSpec
 from importlib._bootstrap_external import FileFinder
 from typing import Any, Callable, Generator, Iterable, List
 
+from ward.models import WardMeta
 from ward.testing import Test, anonymous_tests
-from ward.models import Marker, WardMeta
 
 
 def is_test_module(module: pkgutil.ModuleInfo) -> bool:
@@ -53,15 +53,6 @@ def get_tests_in_modules(modules: Iterable) -> Generator[Test, None, None]:
                     marker=meta.marker,
                     description=meta.description or "",
                 )
-
-        # Collect named tests from the module
-        for item in dir(mod):
-            if item.startswith("test_") and not item == "_":
-                test_name = item
-                test_fn = getattr(mod, test_name)
-                marker: Marker = getattr(test_fn, "ward_meta", WardMeta()).marker
-                if test_fn:
-                    yield Test(fn=test_fn, module_name=mod_name, marker=marker)
 
 
 def search_generally(

--- a/ward/fixtures.py
+++ b/ward/fixtures.py
@@ -1,5 +1,4 @@
 import inspect
-import pprint
 from contextlib import suppress
 from dataclasses import dataclass, field
 from functools import partial, wraps
@@ -31,7 +30,7 @@ class Fixture:
 
     @property
     def path(self):
-        return self.fn.ward_meta.defined_in_file
+        return self.fn.ward_meta.path
 
     @property
     def is_generator_fixture(self):
@@ -94,8 +93,6 @@ class FixtureCache:
         """
         fixtures = self._get_fixtures(fixture.scope, scope_key)
         fixtures[fixture.key] = fixture
-        print("storing", fixture)
-        pprint.pprint(self._scope_cache)
 
     def teardown_fixtures_for_scope(self, scope: Scope, scope_key: ScopeKey):
         fixture_dict = self._get_fixtures(scope, scope_key)
@@ -127,15 +124,15 @@ def fixture(func=None, *, scope: Optional[Union[Scope, str]] = Scope.Test):
     # By setting is_fixture = True, the framework will know
     # that if this fixture is provided as a default arg, it
     # is responsible for resolving the value.
-    file = Path(inspect.getfile(func)).absolute()
+    path = Path(inspect.getfile(func)).absolute()
     if hasattr(func, "ward_meta"):
         func.ward_meta.is_fixture = True
-        func.ward_meta.defined_in_file = file
+        func.ward_meta.path = path
     else:
         func.ward_meta = WardMeta(
             is_fixture=True,
             scope=scope,
-            defined_in_file=file,
+            path=path,
         )
 
     @wraps(func)

--- a/ward/fixtures.py
+++ b/ward/fixtures.py
@@ -99,7 +99,8 @@ class FixtureCache:
         fixtures = list(fixture_dict.values())
         for fixture in fixtures:
             with suppress(RuntimeError, StopIteration):
-                fixture.teardown()
+                if fixture.resolved_val:
+                    fixture.teardown()
             del fixture_dict[fixture.key]
 
     def teardown_global_fixtures(self):

--- a/ward/models.py
+++ b/ward/models.py
@@ -43,3 +43,4 @@ class WardMeta:
     is_fixture: bool = False
     scope: Scope = Scope.Test
     bound_args: Optional[Signature] = None
+    defined_in_file: Optional[str] = None

--- a/ward/models.py
+++ b/ward/models.py
@@ -43,4 +43,4 @@ class WardMeta:
     is_fixture: bool = False
     scope: Scope = Scope.Test
     bound_args: Optional[Signature] = None
-    defined_in_file: Optional[str] = None
+    path: Optional[str] = None

--- a/ward/suite.py
+++ b/ward/suite.py
@@ -1,11 +1,9 @@
-import io
-from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass, field
 from typing import Generator, List
 
+from ward import Scope
 from ward.errors import FixtureError
-from ward.fixtures import FixtureCache, Fixture
-from ward.models import Scope
+from ward.fixtures import FixtureCache
 from ward.testing import Test, TestOutcome, TestResult
 
 
@@ -19,62 +17,40 @@ class Suite:
         return len(self.tests)
 
     def generate_test_runs(self) -> Generator[TestResult, None, None]:
-        previous_test_module = None
-        for test in self.tests:
-            if previous_test_module and test.module_name != previous_test_module:
-                # We've moved into a different module, so clear out all of
-                # the module scoped fixtures from the previous module.
-                to_teardown = self.cache.get(
-                    scope=Scope.Module, module_name=previous_test_module, test_id=None
-                )
-                self.cache.teardown_fixtures(to_teardown)
+        # TODO: Work out when we're finished in a module, and run teardown
+        #   for all module-scoped fixtures inside the cache for that module.
+        #  We're finished in a module when the number of tests we've executed
+        #  in the module == the number of tests in the module
 
+        for test in self.tests:
             generated_tests = test.get_parameterised_instances()
             for i, generated_test in enumerate(generated_tests):
                 marker = generated_test.marker.name if generated_test.marker else None
                 if marker == "SKIP":
                     yield generated_test.get_result(TestOutcome.SKIP)
-                    previous_test_module = generated_test.module_name
                     continue
 
                 try:
                     resolved_vals = generated_test.resolve_args(self.cache, iteration=i)
-
-                    # Run the test, while capturing output.
                     generated_test(**resolved_vals)
-
-                    # The test has completed without exception and therefore passed
                     outcome = (
                         TestOutcome.XPASS if marker == "XFAIL" else TestOutcome.PASS
                     )
                     yield generated_test.get_result(outcome)
-
                 except FixtureError as e:
-                    # We can't run teardown code here because we can't know how much
-                    # of the fixture has been executed.
                     yield generated_test.get_result(TestOutcome.FAIL, e)
-                    previous_test_module = generated_test.module_name
                     continue
 
                 except Exception as e:
-                    # TODO: Differentiate between ExpectationFailed and other Exceptions.
                     outcome = (
                         TestOutcome.XFAIL if marker == "XFAIL" else TestOutcome.FAIL
                     )
                     yield generated_test.get_result(outcome, e)
 
-                self._teardown_fixtures_scoped_to_test(generated_test)
-                previous_test_module = generated_test.module_name
+                self.cache.teardown_fixtures_for_scope(Scope.Test, generated_test.id)
 
-        # Take care of any additional teardown.
-        self.cache.teardown_all()
+                # TODO: Check if we've finished running all tests in the
+                #  current module, and if so, teardown fixtures for that scope
+                #  using the module path as the scope key.
 
-    def _teardown_fixtures_scoped_to_test(self, test: Test):
-        """
-        Get all the test-scoped fixtures that were used to form this result,
-        tear them down from the cache, and return the result.
-        """
-        to_teardown = self.cache.get(
-            scope=Scope.Test, test_id=test.id, module_name=test.module_name
-        )
-        self.cache.teardown_fixtures(to_teardown)
+        self.cache.teardown_global_fixtures()


### PR DESCRIPTION
Rewrite of fixture caching to make it more scalable.

This will allow us to support arbitrary fixture scopes much easier (e.g. Hypothesis example can have their own scope).

The rewrite also stops the previous awkward requirement that tests had to run in sequential order. This means we can now support things like randomised test order, and multi-process mode.