### PR TITLE
Add Makefile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Build Python distributon
+    - name: Build Python distribution
       run: |
         python3 -m pip install --user --upgrade setuptools wheel
         python3 "$GITHUB_WORKSPACE/setup.py" sdist bdist_wheel

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,23 @@
-.idea/
+# Python temp files
 *.pyc
 build/
 dist/
 *.egg-info
 .eggs/
+
+# Virtual environments
+*env*/
+
+bin/
+include/
+lib/
+lib64
+share/
+# The last five directories usually only appear in venvs,
+# so untracking them is a safeguard against cleverly-named
+# virtual environments.
+
+# Developer-specific environment stuff
+.idea/
+.vscode/
+codealike.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+VENV=make-venv
+VENVBIN=$(VENV)/bin
+
+none:
+	@echo "make lint	lint (flake8)"
+	@echo "make format	run autoformatter"
+	@echo "make test	test Ward"
+	@echo "make build	build Ward in preparation for PyPI upload"
+	@echo
+	@echo "make venv	create virtual environment"
+	@echo "make tidy	remove cache, pyc files, and eggs"
+	@echo "make clean	clean up build artifacts and automatically created venv"
+
+venv: make-venv
+.PHONY: venv
+
+make-venv:
+	python3 -m venv make-venv
+	$(VENVBIN)/pip install --upgrade setuptools wheel
+	$(VENVBIN)/pip install flake8 black pycleanup ward
+
+lint: make-venv
+	$(VENVBIN)/flake8 ward --count --select=E9,F63,F7,F82 --show-source --statistics
+	$(VENVBIN)/flake8 ward --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
+.PHONY: lint
+
+format: make-venv
+	$(VENVBIN)/black ward
+.PHONY: format
+
+test: make-venv
+	$(VENVBIN)/ward --path tests
+.PHONY: test
+
+dist: lint format test
+	$(VENVBIN)/python setup.py sdist bdist_wheel
+
+tidy: make-venv
+	$(VENVBIN)/pycleanup --cache --pyc --egg
+
+clean:
+	rm -rf build/
+	rm -rf dist/
+	rm -rf $(VENV)
+.PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
 VENV=make-venv
 VENVBIN=$(VENV)/bin
 
-none:
+none: clean dist tidy
+
+help:
 	@echo "make lint	lint (flake8)"
 	@echo "make format	run autoformatter"
 	@echo "make test	test Ward"
-	@echo "make build	build Ward in preparation for PyPI upload"
+	@echo "make dist	build Ward in preparation for PyPI upload"
 	@echo
 	@echo "make venv	create virtual environment"
 	@echo "make tidy	remove cache, pyc files, and eggs"
 	@echo "make clean	clean up build artifacts and automatically created venv"
+.PHONY: help
 
 venv: make-venv
 .PHONY: venv
@@ -32,8 +35,14 @@ test: make-venv
 	$(VENVBIN)/ward --path tests
 .PHONY: test
 
+prep: lint format test tidy
+.PHONY: prep
+
 dist: lint format test
 	$(VENVBIN)/python setup.py sdist bdist_wheel
+
+build: dist
+.PHONE: dist
 
 tidy: make-venv
 	$(VENVBIN)/pycleanup --cache --pyc --egg


### PR DESCRIPTION
Addresses #38

Here's a few notes:

First, this assumes UNIX-based environment; Makefiles are seldom appropriate for Windows. This should work on any UNIX-like system (Mac/Linux/BSD) with Python 3.6 or later installed. On Ubuntu, you may need to install `python3-venv`, but actually running the Makefile will indirectly prompt the user to install that anyhow. ;)

Second, I'm doing everything in the context of a virtual environment. There's seldom, if ever, a reason not to do this stuff outside of one! The Makefile sets up the venv, installs the necessary packages, and then performs the appropriate tasks.

The virtual environment is never actually activated; its binaries are called directly, and *they* know to only use the venv. It's a neat little trick.

Third, I expanded the `.gitignore`, mainly to prevent virtual environments from getting committed, but secondarily to untrack my own development tools. Hopefully that file is better organized now.

I see no reason why the Actions cannot be adjusted to use the Makefile for almost everything now, but I recommend the primary maintainer be the one to make those adjustments. I'm not overly familiar with Actions yet.

Makefile targets:

* `make`: Runs `clean dist`.
* `make help`: List all (most) targets.
* `make lint`: Run flake8 linters.
* `make format`: Run black
* `make test`: Run tests, bootstrapping with Ward from PyPI
* `make prep`: Gets the code ready to send as a pull request: `lint format test tidy`
* `make build`: Alias for `dist`.
* `make dist`: First runs `lint format test`, and then builds using `setup.py`. This creates `dist/`.
* `make tidy`: Cleans up all cache, `.pyc`, and egg files. (I *adore* `pycleanup`!)
* `make clean`: Removes the `build/`, `dist/`, and `make-venv/` directories. Does *not* call `tidy`, because I don't want `clean` to require the virtual environment.

The `make-venv` target is not listed because I don't like the name; it is only there so that the virtual environment is not recreated if it already exists.