### PR TITLE
Relax Requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ help:
 	@echo "make lint	lint (flake8)"
 	@echo "make format	run autoformatter"
 	@echo "make test	test Ward"
+	@echo
+	@echo "make prep	lint and test Ward in preparation for a pull request"
 	@echo "make dist	build Ward in preparation for PyPI upload"
 	@echo
 	@echo "make venv	create virtual environment"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+colorama>=0.3.3
+termcolor>=1.1.0
+dataclasses>=0.1; python_version < '3.7'
+click>=7.0

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ setup(
         "Topic :: Software Development :: Testing",
     ],
     install_requires=[
-        "colorama==0.4.1",
-        "termcolor==1.1.0",
-        "dataclasses==0.6; python_version < '3.7'",
-        "click==7.0",
+        "colorama>=0.3.3",
+        "termcolor>=1.1.0",
+        "dataclasses>=0.1; python_version < '3.7'",
+        "click>=7.0",
     ],
 )


### PR DESCRIPTION
Resolved #45 

I've ensured that all tests run with a bootstrapped copy of Ward (*not* the PyPI version) on the following versions:

* Python 3.6.10
* Python 3.7.3
* Python 3.8.1

I have yet to test with PyPy3.6, as I don't presently have that installed, but I can't imagine it would be any different.

I've also added `requirements.txt`. Although it is not needed by `setup.py`, and may feel redundant, it's considered good practice to include, even if just to enable `pip install -r requirements.txt`.

The `setup.py` and `requirements.txt` files should have identical requirements; if they don't, I made a mistake, and you can pitch this back to me.

I've confirmed that this works at a minimum of:

* colorama 0.3.3
* termcolor 1.1.0
* click 7.0
* dataclasses 0.1

It also works with all latest versions:

* colorama 0.4.3
* termcolor 1.1.0
* click 7.0
* dataclasses 0.7