### PR TITLE
Ensure module-scoped fixtures and parameterised tests interact correctly

### DIFF
--- a/ward/suite.py
+++ b/ward/suite.py
@@ -28,8 +28,8 @@ class Suite:
         num_tests_per_module = self._test_counts_per_module()
         for test in self.tests:
             generated_tests = test.get_parameterised_instances()
+            num_tests_per_module[test.path] -= 1
             for i, generated_test in enumerate(generated_tests):
-                num_tests_per_module[generated_test.path] -= 1
                 marker = generated_test.marker.name if generated_test.marker else None
                 if marker == "SKIP":
                     yield generated_test.get_result(TestOutcome.SKIP)
@@ -55,9 +55,10 @@ class Suite:
                     self.cache.teardown_fixtures_for_scope(
                         Scope.Test, scope_key=generated_test.id
                     )
-                    if num_tests_per_module[generated_test.path] == 0:
-                        self.cache.teardown_fixtures_for_scope(
-                            Scope.Module, scope_key=generated_test.path
-                        )
+
+            if num_tests_per_module[test.path] == 0:
+                self.cache.teardown_fixtures_for_scope(
+                    Scope.Module, scope_key=str(test.path)
+                )
 
         self.cache.teardown_global_fixtures()


### PR DESCRIPTION
If a module contains parameterised tests that depends on module scoped fixtures, fixture teardown will occur before all tests in the module have been executed. If this module scoped fixture is required again in the same test module, it will be regnerated, but not torn-down again.

This PR attempts to fix that and adds a test to catch this scenario.

The green in the screenshot below shows the order things happen in now when the new test runs with this PR. The red in the screenshot below shows the order of events on 0.23.0b0.

<img width="716" alt="Screenshot 2020-01-19 at 02 59 44" src="https://user-images.githubusercontent.com/5740731/72673876-c9ce3b80-3a67-11ea-8671-e9cdbbcc5b37.png">