### PR TITLE
Add --order "random" option

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -355,13 +355,15 @@ def _():
 
     test_1.ward_meta.path = "module1"
     test_2.ward_meta.path = "module2"
-    test_3.ward_meta.path = "module2"
+    test_3.ward_meta.path = "module1"
 
     suite = Suite(
         tests=[
+            # Module ordering is intentionally off here, to ensure correct
+            # interaction between module-scope fixtures and random ordering
             Test(fn=test_1, module_name="module1"),
             Test(fn=test_2, module_name="module2"),
-            Test(fn=test_3, module_name="module2"),
+            Test(fn=test_3, module_name="module1"),
         ]
     )
 
@@ -374,15 +376,15 @@ def _():
             "resolve c",  # test fixture resolved at start of test1
             "test1",
             "teardown c",  # test fixture teardown at start of test1
-            "teardown b",  # module fixture teardown at end of module1
             "resolve b",  # module fixture resolved at start of module2
             "resolve c",  # test fixture resolved at start of test2
             "test2",
             "teardown c",  # test fixture teardown at start of test2
+            "teardown b",  # module fixture teardown at end of module2
             "resolve c",  # test fixture resolved at start of test3
             "test3",
             "teardown c",  # test fixture teardown at end of test3
-            "teardown b",  # module fixture teardown at end of module2
+            "teardown b",  # module fixture teardown at end of module1
             "teardown a",  # global fixtures are torn down at the very end
         ]
     )

--- a/ward/run.py
+++ b/ward/run.py
@@ -28,12 +28,12 @@ sys.path.append(".")
     "--path",
     default=".",
     type=click.Path(exists=True),
-    help="Path to tests.",
+    help="Path to test directory.",
     multiple=True,
 )
 @click.option(
     "--search",
-    help="Search test names, descriptions and module names for the search query and only run matching tests.",
+    help="Search test names, bodies, descriptions and module names for the search query and only run matching tests.",
 )
 @click.option(
     "--fail-limit",
@@ -52,6 +52,7 @@ sys.path.append(".")
         ["standard", "random"], case_sensitive=False
     ),
     default="standard",
+    help="Specify the order in which tests should run.",
 )
 @click.version_option(version=__version__)
 def run(path, search, fail_limit, test_output_style, order):

--- a/ward/suite.py
+++ b/ward/suite.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass, field
+from random import shuffle
 from typing import Generator, List
 
 from ward import Scope
@@ -24,7 +25,9 @@ class Suite:
             counts[path] += 1
         return counts
 
-    def generate_test_runs(self) -> Generator[TestResult, None, None]:
+    def generate_test_runs(self, order="standard") -> Generator[TestResult, None, None]:
+        if order == "random":
+            shuffle(self.tests)
         num_tests_per_module = self._test_counts_per_module()
         for test in self.tests:
             generated_tests = test.get_parameterised_instances()


### PR DESCRIPTION
Adds `ward --order "random"` which lets you run tests in a random order.

This reduces the likelihood of hidden interdependencies between tests.