### PR TITLE
Convert tests to assert

### DIFF
--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -37,7 +37,7 @@ def _():
 @test("equals should raise an ExpectationFailed when args aren't equal")
 def _():
     with raises(ExpectationFailed):
-        expect(1).equals(2)
+        assert 1 == 2
 
 
 @test("satisfies should record history when arg satisfies predicate")

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from tests.test_suite import testable_test
-from ward import expect, fixture, test, Scope
+from ward import fixture, test, Scope
 from ward.fixtures import Fixture, FixtureCache, using
 from ward.testing import Test
 
@@ -20,7 +20,7 @@ def _(f=exception_raising_fixture):
     cache = FixtureCache()
     cache.cache_fixture(f, "test_id")
 
-    expect(cache.get(f.key, Scope.Test, "test_id")).equals(f)
+    assert cache.get(f.key, Scope.Test, "test_id") == f
 
 
 @fixture
@@ -87,8 +87,8 @@ def _(cache: FixtureCache = cache, t: Test = my_test, default_fixture=default_fi
 
     fixture = list(fixtures_at_scope.values())[0]
 
-    expect(fixtures_at_scope).has_length(1)
-    expect(fixture.fn).equals(default_fixture)
+    assert len(fixtures_at_scope) == 1
+    assert fixture.fn == default_fixture
 
 
 @test("FixtureCache.get_fixtures_at_scope correct for Scope.Module")
@@ -97,8 +97,8 @@ def _(cache: FixtureCache = cache, module_fixture=module_fixture):
 
     fixture = list(fixtures_at_scope.values())[0]
 
-    expect(fixtures_at_scope).has_length(1)
-    expect(fixture.fn).equals(module_fixture)
+    assert len(fixtures_at_scope) == 1
+    assert fixture.fn == module_fixture
 
 
 @test("FixtureCache.get_fixtures_at_scope correct for Scope.Global")
@@ -107,8 +107,8 @@ def _(cache: FixtureCache = cache, global_fixture=global_fixture):
 
     fixture = list(fixtures_at_scope.values())[0]
 
-    expect(fixtures_at_scope).has_length(1)
-    expect(fixture.fn).equals(global_fixture)
+    assert len(fixtures_at_scope) == 1
+    assert fixture.fn == global_fixture
 
 
 @test("FixtureCache.teardown_fixtures_for_scope removes Test fixtures from cache")
@@ -117,46 +117,46 @@ def _(cache: FixtureCache = cache, t: Test = my_test):
 
     fixtures_at_scope = cache.get_fixtures_at_scope(Scope.Test, t.id)
 
-    expect(fixtures_at_scope).equals({})
+    assert fixtures_at_scope == {}
 
 
 @test("FixtureCache.teardown_fixtures_for_scope runs teardown for Test fixtures")
 def _(cache: FixtureCache = cache, t: Test = my_test, events: List = recorded_events):
     cache.teardown_fixtures_for_scope(Scope.Test, t.id)
 
-    expect(events).equals(["teardown t"])
+    assert events == ["teardown t"]
 
 
 @test("FixtureCache.teardown_fixtures_for_scope removes Module fixtures from cache")
-def _(cache: FixtureCache = cache,):
+def _(cache: FixtureCache = cache, ):
     cache.teardown_fixtures_for_scope(Scope.Module, testable_test.path)
 
     fixtures_at_scope = cache.get_fixtures_at_scope(Scope.Module, testable_test.path)
 
-    expect(fixtures_at_scope).equals({})
+    assert fixtures_at_scope == {}
 
 
 @test("FixtureCache.teardown_fixtures_for_scope runs teardown for Module fixtures")
 def _(cache: FixtureCache = cache, events: List = recorded_events):
     cache.teardown_fixtures_for_scope(Scope.Module, testable_test.path)
 
-    expect(events).equals(["teardown m"])
+    assert events == ["teardown m"]
 
 
 @test("FixtureCache.teardown_global_fixtures removes Global fixtures from cache")
-def _(cache: FixtureCache = cache,):
+def _(cache: FixtureCache = cache, ):
     cache.teardown_global_fixtures()
 
     fixtures_at_scope = cache.get_fixtures_at_scope(Scope.Global, Scope.Global)
 
-    expect(fixtures_at_scope).equals({})
+    assert fixtures_at_scope == {}
 
 
 @test("FixtureCache.teardown_global_fixtures runs teardown of all Global fixtures")
 def _(cache: FixtureCache = cache, events: List = recorded_events):
     cache.teardown_global_fixtures()
 
-    expect(events).equals(["teardown g"])
+    assert events == ["teardown g"]
 
 
 @test("using decorator sets bound args correctly")
@@ -173,4 +173,4 @@ def _():
     bound_args = t.ward_meta.bound_args
     expected = {"a": fixture_a, "b": "val"}
 
-    expect(bound_args.arguments).equals(expected)
+    assert bound_args.arguments == expected

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -2,14 +2,14 @@ from unittest import mock
 from unittest.mock import Mock
 
 from tests.test_suite import testable_test
-from ward import expect, raises, Scope
+from ward import raises, Scope
 from ward.errors import ParameterisationError
 from ward.fixtures import fixture
 from ward.testing import Test, test, each, ParamMeta
 
 
 def f():
-    expect(1).equals(1)
+    assert 1 == 1
 
 
 mod = "my_module"
@@ -20,7 +20,7 @@ t = Test(fn=f, module_name=mod)
 def anonymous_test():
     @testable_test
     def _():
-        expect(1).equals(1)
+        assert 1 == 1
 
     return Test(fn=_, module_name=mod)
 
@@ -31,45 +31,45 @@ def dependent_test():
         return 1
 
     def _(a=x):
-        expect(1).equals(1)
+        assert 1 == 1
 
     return Test(fn=_, module_name=mod)
 
 
 @test("Test.name should return the name of the function it wraps")
 def _(anonymous_test=anonymous_test):
-    expect(anonymous_test.name).equals("_")
+    assert anonymous_test.name == "_"
 
 
 @test("Test.qualified_name should return `module_name.function_name`")
 def _():
-    expect(t.qualified_name).equals(f"{mod}.{f.__name__}")
+    assert t.qualified_name == f"{mod}.{f.__name__}"
 
 
 @test("Test.qualified_name should return `module_name._` when test name is _")
 def _(anonymous_test=anonymous_test):
-    expect(anonymous_test.qualified_name).equals(f"{mod}._")
+    assert anonymous_test.qualified_name == f"{mod}._"
 
 
 @test("Test.deps should return {} when test uses no fixtures")
 def _(anonymous_test=anonymous_test):
-    expect(anonymous_test.deps()).equals({})
+    assert anonymous_test.deps() == {}
 
 
 @test("Test.deps should return correct params when test uses fixtures")
 def _(dependent_test=dependent_test):
     deps = dependent_test.deps()
-    expect(deps).contains("a")
+    assert "a" in deps
 
 
 @test("Test.has_deps should return True when test uses fixtures")
 def _(dependent_test=dependent_test):
-    expect(dependent_test.has_deps).equals(True)
+    assert dependent_test.has_deps
 
 
 @test("Test.has_deps should return False when test doesn't use fixtures")
 def _(anonymous_test=anonymous_test):
-    expect(anonymous_test.has_deps).equals(False)
+    assert not anonymous_test.has_deps
 
 
 @test("Test.__call__ should delegate to the function it wraps")
@@ -77,7 +77,7 @@ def _():
     mock = Mock()
     t = Test(fn=mock, module_name=mod)
     t(1, 2, key="val")
-    expect(mock).called_once_with(1, 2, key="val")
+    mock.assert_called_once_with(1, 2, key="val")
 
 
 @test("Test.is_parameterised should return True for parameterised test")
@@ -87,7 +87,7 @@ def _():
 
     t = Test(fn=parameterised_test, module_name=mod)
 
-    expect(t.is_parameterised).equals(True)
+    assert t.is_parameterised == True
 
 
 @test("Test.is_parameterised should return False for standard tests")
@@ -97,28 +97,28 @@ def _():
 
     t = Test(fn=test, module_name=mod)
 
-    expect(t.is_parameterised).equals(False)
+    assert not t.is_parameterised
 
 
 @test("Test.scope_key_from(Scope.Test) returns the test ID")
 def _(t: Test = anonymous_test):
     scope_key = t.scope_key_from(Scope.Test)
 
-    expect(scope_key).equals(t.id)
+    assert scope_key == t.id
 
 
 @test("Test.scope_key_from(Scope.Module) returns the path of the test module")
 def _(t: Test = anonymous_test):
     scope_key = t.scope_key_from(Scope.Module)
 
-    expect(scope_key).equals(testable_test.path)
+    assert scope_key == testable_test.path
 
 
 @test("Test.scope_key_from(Scope.Global) returns Scope.Global")
 def _(t: Test = anonymous_test):
     scope_key = t.scope_key_from(Scope.Global)
 
-    expect(scope_key).equals(Scope.Global)
+    assert scope_key == Scope.Global
 
 
 @test("Test.get_parameterised_instances returns [self] if not parameterised")
@@ -128,7 +128,7 @@ def _():
 
     t = Test(fn=test, module_name=mod)
 
-    expect(t.get_parameterised_instances()).equals([t])
+    assert t.get_parameterised_instances() == [t]
 
 
 @test("Test.get_parameterised_instances returns correct number of test instances")
@@ -137,26 +137,24 @@ def _():
         pass
 
     t = Test(fn=test, module_name=mod)
-    expect(t.get_parameterised_instances()).equals(
-        [
-            Test(
-                id=mock.ANY,
-                fn=t.fn,
-                module_name=t.module_name,
-                param_meta=ParamMeta(0, 2),
-                sout=mock.ANY,
-                serr=mock.ANY,
-            ),
-            Test(
-                id=mock.ANY,
-                fn=t.fn,
-                module_name=t.module_name,
-                param_meta=ParamMeta(1, 2),
-                sout=mock.ANY,
-                serr=mock.ANY,
-            ),
-        ]
-    )
+    assert t.get_parameterised_instances() == [
+        Test(
+            id=mock.ANY,
+            fn=t.fn,
+            module_name=t.module_name,
+            param_meta=ParamMeta(0, 2),
+            sout=mock.ANY,
+            serr=mock.ANY,
+        ),
+        Test(
+            id=mock.ANY,
+            fn=t.fn,
+            module_name=t.module_name,
+            param_meta=ParamMeta(1, 2),
+            sout=mock.ANY,
+            serr=mock.ANY,
+        ),
+    ]
 
 
 @test("Test.get_parameterised_instances raises exception for arg count mismatch")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,14 +21,14 @@ def _(example):
     ]
     exit_code = get_exit_code(test_results)
 
-    expect(exit_code).equals(ExitCode.SUCCESS)
+    assert exit_code == ExitCode.SUCCESS
 
 
 @test("get_exit_code returns ExitCode.SUCCESS when no test results")
 def _():
     exit_code = get_exit_code([])
 
-    expect(exit_code).equals(ExitCode.NO_TESTS_FOUND)
+    assert exit_code == ExitCode.NO_TESTS_FOUND
 
 
 @test("get_exit_code returns ExitCode.FAILED when XPASS in test results")
@@ -39,7 +39,7 @@ def _(example=example_test):
     ]
     exit_code = get_exit_code(test_results)
 
-    expect(exit_code).equals(ExitCode.FAILED)
+    assert exit_code == ExitCode.FAILED
 
 
 @fixture
@@ -52,7 +52,7 @@ def _(
     input=s, num_chars=each(20, 11, 10, 5), expected=each(s, s, "hello w...", "he...")
 ):
     result = truncate(input, num_chars)
-    expect(result).equals(expected)
+    assert result == expected
 
 
 @test("outcome_to_colour({outcome}) returns '{colour}'")
@@ -60,14 +60,14 @@ def _(
     outcome=each(TestOutcome.PASS, TestOutcome.SKIP, TestOutcome.FAIL, TestOutcome.XFAIL, TestOutcome.XPASS),
     colour=each("green", "blue", "red", "magenta", "yellow"),
 ):
-    expect(outcome_to_colour(outcome)).equals(colour)
+    assert outcome_to_colour(outcome) == colour
 
 
 @test("find_project_root returns the root dir if no paths supplied")
 def _():
     project_root = find_project_root([])
     fs_root = os.path.normpath(os.path.abspath(os.sep))
-    expect(project_root).equals(Path(fs_root))
+    assert project_root == Path(fs_root)
 
 
 def make_project(root_file: str):
@@ -103,5 +103,5 @@ def fake_project_git():
 @test("find_project_root finds project root with '{root_file}' file")
 def _(root_file, project):
     root = find_project_root([project / "a/b/c", project / "a/d"])
-    expect(root.resolve()).equals(project.resolve())
-    expect((root / root_file).exists()).equals(True)
+    assert root.resolve() == project.resolve()
+    assert (root / root_file).exists() == True

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,7 @@ import tempfile
 from pathlib import Path
 
 from tests.test_suite import example_test
-from ward import expect, test, using, fixture
+from ward import test, using, fixture
 from ward.testing import TestOutcome, TestResult, each
 from ward.util import ExitCode, get_exit_code, truncate, outcome_to_colour, find_project_root
 


### PR DESCRIPTION
Converts the remaining test suite for Ward to use plain `assert` statements instead of the `expect` API.