### PR TITLE
Fix test module imports bug

### DIFF
--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from tests.test_suite import testable_test
+from tests.utilities import testable_test
 from ward import fixture, test, Scope
 from ward.fixtures import Fixture, FixtureCache, using
 from ward.testing import Test

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -1,6 +1,6 @@
 import ast
 
-from tests.test_suite import testable_test
+from tests.utilities import testable_test
 from ward import test, fixture
 from ward.rewrite import (
     rewrite_assertions_in_tests,

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1,65 +1,11 @@
-from collections import defaultdict
-from pathlib import Path
 from unittest import mock
 
+from tests.utilities import NUMBER_OF_TESTS, testable_test, example_test, module
 from ward import fixture
-from ward.fixtures import Fixture
 from ward.models import Scope, SkipMarker
 from ward.suite import Suite
 from ward.testing import Test, skip, TestOutcome, TestResult, test, each
 
-NUMBER_OF_TESTS = 5
-FORCE_TEST_PATH = Path("path/of/test").absolute()
-
-
-def testable_test(func):
-    return test(
-        "testable test description",
-        _force_path=FORCE_TEST_PATH,
-        _collect_into=defaultdict(list),
-    )(func)
-
-
-testable_test.path = FORCE_TEST_PATH
-
-
-@fixture
-def module():
-    return "test_module"
-
-
-@fixture
-def fixture_b():
-    def b():
-        return 2
-
-    return b
-
-
-@fixture
-def fixture_a(b=fixture_b):
-    def a(b=b):
-        return b * 2
-
-    return a
-
-
-@fixture
-def fixtures(a=fixture_a, b=fixture_b):
-    return {"fixture_a": Fixture(fn=a), "fixture_b": Fixture(fn=b)}
-
-
-@fixture
-def example_test(module=module, fixtures=fixtures):
-    @fixture
-    def f():
-        return 123
-
-    @testable_test
-    def t(fix_a=f):
-        return fix_a
-
-    return Test(fn=t, module_name=module)
 
 
 @fixture

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -7,7 +7,6 @@ from ward.suite import Suite
 from ward.testing import Test, skip, TestOutcome, TestResult, test, each
 
 
-
 @fixture
 def skipped_test(module=module):
     @testable_test

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,4 +1,4 @@
-from tests.test_suite import example_test
+from tests.utilities import example_test
 from ward import using
 from ward.terminal import outcome_to_colour, get_exit_code, ExitCode
 from ward.testing import TestOutcome, each, test, TestResult

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -249,3 +249,21 @@ def _(func=example_test):
     path = Path("p")
     test("test", _collect_into=dest, _force_path=path)(func)
     assert dest[path.absolute()] == [func]
+
+
+@test("@test doesn't collect items from non-test modules")
+def _(func=example_test):
+    func.__module__ = "run"
+    dest = defaultdict(list)
+    path = Path("p")
+    test("test", _collect_into=dest, _force_path=path)(func)
+    assert len(dest) == 0
+
+
+@test("@test doesn't tests imported from another test module")
+def _(func=example_test):
+    func.__module__ = "test_contains.dot_test"
+    dest = defaultdict(list)
+    path = Path("p")
+    test("test", _collect_into=dest, _force_path=path)(func)
+    assert len(dest) == 0

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock
 
@@ -197,11 +199,12 @@ def _():
 def example_test():
     def func():
         assert 1 < 2
+
     return func
+
 
 @test("@test attaches correct WardMeta to test function it wraps")
 def _(func=example_test):
-
     out_func = testable_test(func)
 
     assert out_func.ward_meta == WardMeta(
@@ -238,3 +241,11 @@ def _(func=example_test):
     out_func = test("test")(func)
 
     assert not hasattr(out_func, "ward_meta")
+
+
+@test("@test collects tests into specified data structure")
+def _(func=example_test):
+    dest = defaultdict(list)
+    path = Path("p")
+    test("test", _collect_into=dest, _force_path=path)(func)
+    assert dest[path.absolute()] == [func]

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 import sys
 
-from tests.test_suite import testable_test
+from tests.utilities import testable_test
 from ward import raises, Scope
 from ward.errors import ParameterisationError
 from ward.fixtures import fixture

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -1,0 +1,60 @@
+from collections import defaultdict
+from pathlib import Path
+
+from ward import test, fixture
+from ward.fixtures import Fixture
+from ward.testing import Test
+
+NUMBER_OF_TESTS = 5
+FORCE_TEST_PATH = Path("path/of/test").absolute()
+
+
+def testable_test(func):
+    return test(
+        "testable test description",
+        _force_path=FORCE_TEST_PATH,
+        _collect_into=defaultdict(list),
+    )(func)
+
+
+testable_test.path = FORCE_TEST_PATH
+
+@fixture
+def fixture_b():
+    def b():
+        return 2
+
+    return b
+
+
+@fixture
+def fixture_a(b=fixture_b):
+    def a(b=b):
+        return b * 2
+
+    return a
+
+
+@fixture
+def fixtures(a=fixture_a, b=fixture_b):
+    return {"fixture_a": Fixture(fn=a), "fixture_b": Fixture(fn=b)}
+
+@fixture
+def module():
+    return "test_module"
+
+@fixture
+def example_test(module=module, fixtures=fixtures):
+    @fixture
+    def f():
+        return 123
+
+    @testable_test
+    def t(fix_a=f):
+        return fix_a
+
+    return Test(fn=t, module_name=module)
+
+
+
+

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -3,13 +3,21 @@ from pathlib import Path
 
 from ward import test, fixture
 from ward.fixtures import Fixture
-from ward.testing import Test
+from ward.testing import Test, is_test_module_name
 
 NUMBER_OF_TESTS = 5
 FORCE_TEST_PATH = Path("path/of/test").absolute()
 
 
 def testable_test(func):
+    """
+    Decorate a function with this to treat it as a test that doesn't
+    interfere with the "normal" tests, i.e. it collects into a separate
+    location, uses a static path, module name etc. Useful for writing
+    Ward internal tests.
+    """
+    func.__module__ = "test_x"
+    assert is_test_module_name(func.__module__)
     return test(
         "testable test description",
         _force_path=FORCE_TEST_PATH,
@@ -18,6 +26,7 @@ def testable_test(func):
 
 
 testable_test.path = FORCE_TEST_PATH
+
 
 @fixture
 def fixture_b():
@@ -39,9 +48,11 @@ def fixture_a(b=fixture_b):
 def fixtures(a=fixture_a, b=fixture_b):
     return {"fixture_a": Fixture(fn=a), "fixture_b": Fixture(fn=b)}
 
+
 @fixture
 def module():
     return "test_module"
+
 
 @fixture
 def example_test(module=module, fixtures=fixtures):
@@ -54,7 +65,3 @@ def example_test(module=module, fixtures=fixtures):
         return fix_a
 
     return Test(fn=t, module_name=module)
-
-
-
-

--- a/ward/collect.py
+++ b/ward/collect.py
@@ -9,12 +9,12 @@ from pathlib import Path
 from typing import Any, Callable, Generator, Iterable, List, Set
 
 from ward.models import WardMeta
-from ward.testing import Test, anonymous_tests
+from ward.testing import Test, anonymous_tests, is_test_module_name
 from ward.util import get_absolute_path
 
 
 def is_test_module(module: pkgutil.ModuleInfo) -> bool:
-    return module.name.startswith("test_")
+    return is_test_module_name(module.name)
 
 
 def get_info_for_modules(

--- a/ward/testing.py
+++ b/ward/testing.py
@@ -112,7 +112,7 @@ class Test:
         return self.fn(*args, **kwargs)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.fn.__name__
 
     @property
@@ -120,12 +120,12 @@ class Test:
         return self.fn.ward_meta.path
 
     @property
-    def qualified_name(self):
+    def qualified_name(self) -> str:
         name = self.name or ""
         return f"{self.module_name}.{name}"
 
     @property
-    def line_number(self):
+    def line_number(self) -> int:
         return inspect.getsourcelines(self.fn)[1]
 
     @property
@@ -194,7 +194,7 @@ class Test:
                 return self._resolve_args(cache, iteration)
         return self._resolve_args(cache, iteration)
 
-    def _resolve_args(self, cache, iteration):
+    def _resolve_args(self, cache: FixtureCache, iteration: int) -> Dict[str, Any]:
         if not self.has_deps:
             return {}
         default_args = self._get_default_args()
@@ -372,11 +372,8 @@ def test(description: str, *args, **kwargs):
         else:
             unwrapped.ward_meta = WardMeta(description=description, path=path)
 
-        collect_into = kwargs.get("_collect_into")
-        if collect_into is not None:
-            collect_into[path].append(unwrapped)
-        else:
-            anonymous_tests[path].append(unwrapped)
+        collect_into = kwargs.get("_collect_into", anonymous_tests)
+        collect_into[path].append(unwrapped)
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
Fixes a bug around importing something from a module containing tests causing tests to sometimes run more than once. This PR ensures we only run tests for the module they're defined in, and not again in modules they're imported into. Also massively improves test coverage around this area.