### PR TITLE
Give access to the exception after "with raises"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-VENV=make-venv
-VENVBIN=$(VENV)/bin
+VENV := make-venv
+VENVBIN := $(VENV)/bin
+SOURCES := $(shell find ward -name "*.py")
 
 none: clean dist tidy
 
@@ -33,9 +34,13 @@ format: make-venv
 	$(VENVBIN)/black ward
 .PHONY: format
 
-test: make-venv
+test: $(VENV)/.install-self
 	$(VENVBIN)/ward --path tests
 .PHONY: test
+
+$(VENV)/.install-self: make-venv $(SOURCES)
+	$(VENVBIN)/pip install .
+	@touch $(VENV)/.install-self
 
 prep: lint format test tidy
 .PHONY: prep

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test: $(VENV)/.install-self
 
 $(VENV)/.install-self: make-venv $(SOURCES)
 	$(VENVBIN)/pip install .
-	@touch $(VENV)/.install-self
+	@touch $@
 
 prep: lint format test tidy
 .PHONY: prep

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ venv: make-venv
 
 make-venv:
 	python3 -m venv make-venv
+	$(VENVBIN)/pip install --upgrade pip
 	$(VENVBIN)/pip install .[dev]
 
 lint: make-venv

--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -54,3 +54,53 @@ def _(
 ):
     with raises(TestFailure):
         func(lhs, rhs, "")
+
+
+@test("ward.raises raises AssertionError if the expected error is not raised")
+def _():
+    with raises(AssertionError):
+        with raises(ValueError):
+            raise RuntimeError
+
+
+@test("ward.raises doesn't raise if the expected error is raised")
+def _():
+    with raises(ValueError):
+        raise ValueError
+
+
+@test("ward.raises gives access to the raised error afterwards")
+def _():
+    err = ValueError("x")
+    with raises(ValueError) as ctx:
+        raise err
+    assert ctx.raised is err
+
+
+@test("ward.raises allows to easily check the error message")
+def _():
+    with raises(ValueError) as ctx:
+        raise ValueError("xyz")
+    assert "y" in str(ctx.raised)
+
+
+@test("ward.raises.raised and try/except include a similar traceback")
+def _():
+    import traceback
+
+    def raising():
+        raise ValueError
+
+    def dangerous():
+        raising()
+
+    try:
+        dangerous()
+    except ValueError as err:
+        try_tb = traceback.extract_tb(err.__traceback__)
+
+    with raises(ValueError) as ctx:
+        dangerous()
+    raises_tb = traceback.extract_tb(ctx.raised.__traceback__)
+
+    assert try_tb[1:] == raises_tb[1:]

--- a/ward/expect.py
+++ b/ward/expect.py
@@ -1,20 +1,31 @@
 import inspect
+import types
 from enum import Enum
-from typing import Type, Any
+from typing import Type, Any, ContextManager, TypeVar, Generic, Optional, cast
+
+_E = TypeVar("_E", bound=Exception)
 
 
-class raises:
-    def __init__(self, expected_ex_type: Type[Exception]):
+class raises(Generic[_E], ContextManager["raises[_E]"]):
+    raised: _E
+
+    def __init__(self, expected_ex_type: Type[_E]):
         self.expected_ex_type = expected_ex_type
 
-    def __enter__(self):
-        pass
+    def __enter__(self) -> "raises[_E]":
+        return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[types.TracebackType],
+    ) -> bool:
         if exc_type is not self.expected_ex_type:
             raise AssertionError(
                 f"Expected exception {self.expected_ex_type}, but {exc_type} was raised instead."
             )
+        self.raised: _E = cast(_E, exc_val)
         return True
 
 

--- a/ward/rewrite.py
+++ b/ward/rewrite.py
@@ -110,7 +110,7 @@ def rewrite_assertion(test: Test) -> Test:
     # We dedented the code so that it was a valid tree, now re-apply the indent
     for child in ast.walk(new_tree):
         if hasattr(child, "col_offset"):
-            child.col_offset = getattr(child, 'col_offset', 0) + col_offset
+            child.col_offset = getattr(child, "col_offset", 0) + col_offset
 
     # Reconstruct the test function
     new_mod_code_obj = compile(new_tree, code_obj.co_filename, "exec")


### PR DESCRIPTION
Fixes #121. Makes it possible to write:

```py
with raises(ValueError) as ctx:
  raise ValueError("hi")
assert str(ctx.raised) == "hi"
```

This is similar to [how Pytest does it](https://docs.pytest.org/en/latest/assert.html#assertraises), except that Pytest returns a custom wrapper around the exception ([`ExceptionInfo`](https://docs.pytest.org/en/latest/reference.html#exceptioninfo)), whereas in this PR Ward returns the context manager object itself. I'm honestly not sure which is best. I didn't immediately see a separate wrapper adding much value, and by returning the context manager object you still have access to the `expected_ex_type` later if you need it. But I'm really interested in any opinion about this.

Initially I wanted to return the exception object itself (it just feels more natural), but I don't think that is possible (and I think that's why Pytest returns a wrapper). Indeed, the "as" variable is populated by the context manager's `__enter__` method, when the exception object doesn't yet exist. In a C-like language, we would be able to play with pointers to set the value of that variable to what we want in `__exit__`, but I don't know how to do the same in Python.

