### PR TITLE
Include location footer in logs for AssertionErrors

### DIFF
--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -499,7 +499,9 @@ class SimpleTestResultWrite(TestResultWriterBase):
         )
 
     def output_test_failed_location(self, test_result: TestResult):
-        if isinstance(test_result.error, TestFailure):
+        if isinstance(test_result.error, TestFailure) or isinstance(
+            test_result.error, AssertionError
+        ):
             print(
                 indent(colored("Location:", color="cyan", attrs=["bold"]), INDENT),
                 f"{test_result.test.path.relative_to(Path.cwd())}:{test_result.error.error_line}",

--- a/ward/testing.py
+++ b/ward/testing.py
@@ -1,5 +1,7 @@
 import functools
 import inspect
+import sys
+import traceback
 import uuid
 from collections import defaultdict
 from contextlib import closing, redirect_stderr, redirect_stdout
@@ -217,6 +219,11 @@ class Test:
             if outcome in (TestOutcome.PASS, TestOutcome.SKIP):
                 result = TestResult(self, outcome)
             else:
+                if isinstance(exception, AssertionError):
+                    exception.error_line = traceback.extract_tb(
+                        exception.__traceback__, limit=-1
+                    )[0].lineno
+
                 result = TestResult(
                     self,
                     outcome,


### PR DESCRIPTION
Changes:
```
1. Adding Location footer in AssertionErrors.
```

Concerns:
```
1. Didn't add tests for the change as I can't find other tests for the Locations.
2. Approach doesn't seem clean to me, not sure if how we can improve it.
```
[issue #126 ](https://github.com/darrenburns/ward/issues/126)