### PR TITLE
Add --dry-run option to print tests without execution

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -80,6 +80,19 @@ def _(skipped=skipped_test, example=example_test):
 
     assert test_runs == expected_runs
 
+@test("Suite.generate_test_runs yields a DRYRUN TestResult when dry_run is True")
+def _(skipped=skipped_test, example=example_test):
+    suite = Suite(tests=[example, skipped])
+
+    test_runs = list(suite.generate_test_runs(dry_run=True))
+
+    expected_runs = [
+        TestResult(example, TestOutcome.DRYRUN, None, ""),
+        TestResult(skipped, TestOutcome.SKIP, None, ""),
+    ]
+
+    assert test_runs == expected_runs
+
 
 @test("Suite.generate_test_runs fixture teardown code is ran in the expected order")
 def _(module=module):

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -45,7 +45,8 @@ def _(
         TestOutcome.FAIL,
         TestOutcome.XFAIL,
         TestOutcome.XPASS,
+        TestOutcome.DRYRUN,
     ),
-    colour=each("green", "blue", "red", "magenta", "yellow"),
+    colour=each("green", "blue", "red", "magenta", "yellow", "green"),
 ):
     assert outcome_to_colour(outcome) == colour

--- a/ward/run.py
+++ b/ward/run.py
@@ -80,6 +80,11 @@ sys.path.append(".")
     help="Record and display duration of n longest running tests",
     default=0,
 )
+@click.option(
+    "--dry-run/--no-dry-run",
+    help="Print all tests without executing them",
+    default=False,
+)
 @click.pass_context
 def run(
     ctx: click.Context,
@@ -92,6 +97,7 @@ def run(
     capture_output: bool,
     config: str,
     show_slowest: int,
+    dry_run: bool,
 ):
     start_run = default_timer()
     paths = [Path(p) for p in path]
@@ -106,7 +112,7 @@ def run(
     time_to_collect = default_timer() - start_run
 
     suite = Suite(tests=tests)
-    test_results = suite.generate_test_runs(order=order)
+    test_results = suite.generate_test_runs(order=order, dry_run=dry_run)
 
     writer = SimpleTestResultWrite(suite=suite, test_output_style=test_output_style)
     results = writer.output_all_test_results(

--- a/ward/suite.py
+++ b/ward/suite.py
@@ -24,7 +24,9 @@ class Suite:
             counts[path] += 1
         return counts
 
-    def generate_test_runs(self, order="standard") -> Generator[TestResult, None, None]:
+    def generate_test_runs(
+        self, order="standard", dry_run=False
+    ) -> Generator[TestResult, None, None]:
         """
         Run tests
 
@@ -39,7 +41,7 @@ class Suite:
             generated_tests = test.get_parameterised_instances()
             num_tests_per_module[test.path] -= 1
             for generated_test in generated_tests:
-                yield generated_test.run(self.cache)
+                yield generated_test.run(self.cache, dry_run=dry_run)
                 self.cache.teardown_fixtures_for_scope(
                     Scope.Test, scope_key=generated_test.id
                 )

--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -413,7 +413,7 @@ class SimpleTestResultWrite(TestResultWriterBase):
                 num_skipped=outcome_counts[TestOutcome.SKIP],
                 num_xfail=outcome_counts[TestOutcome.XFAIL],
                 num_unexp=outcome_counts[TestOutcome.XPASS],
-                num_printed=outcome_counts[TestOutcome.DRYRUN],
+                num_dryrun=outcome_counts[TestOutcome.DRYRUN],
             )
             print(chart, "")
 
@@ -482,19 +482,19 @@ class SimpleTestResultWrite(TestResultWriterBase):
                 print(indent(line, DOUBLE_INDENT))
 
     def generate_chart(
-        self, num_passed, num_failed, num_skipped, num_xfail, num_unexp, num_printed
+        self, num_passed, num_failed, num_skipped, num_xfail, num_unexp, num_dryrun
     ):
         num_tests = (
-            num_passed + num_failed + num_skipped + num_xfail + num_unexp + num_printed
+            num_passed + num_failed + num_skipped + num_xfail + num_unexp + num_dryrun
         )
         pass_pct = num_passed / max(num_tests, 1)
         fail_pct = num_failed / max(num_tests, 1)
         xfail_pct = num_xfail / max(num_tests, 1)
         unexp_pct = num_unexp / max(num_tests, 1)
-        printed_pct = num_printed / max(num_tests, 1)
-        skip_pct = 1.0 - pass_pct - fail_pct - xfail_pct - unexp_pct - printed_pct
+        dryrun_pct = num_dryrun / max(num_tests, 1)
+        skip_pct = 1.0 - pass_pct - fail_pct - xfail_pct - unexp_pct - dryrun_pct
 
-        num_green_bars = int((pass_pct + printed_pct) * self.terminal_size.width)
+        num_green_bars = int((pass_pct + dryrun_pct) * self.terminal_size.width)
         num_red_bars = int(fail_pct * self.terminal_size.width)
         num_blue_bars = int(skip_pct * self.terminal_size.width)
         num_yellow_bars = int(unexp_pct * self.terminal_size.width)

--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -413,6 +413,7 @@ class SimpleTestResultWrite(TestResultWriterBase):
                 num_skipped=outcome_counts[TestOutcome.SKIP],
                 num_xfail=outcome_counts[TestOutcome.XFAIL],
                 num_unexp=outcome_counts[TestOutcome.XPASS],
+                num_printed=outcome_counts[TestOutcome.DRYRUN],
             )
             print(chart, "")
 
@@ -436,6 +437,8 @@ class SimpleTestResultWrite(TestResultWriterBase):
             output += f"{colored(str(outcome_counts[TestOutcome.SKIP]) + ' skipped', color='blue')}  "
         if outcome_counts[TestOutcome.PASS]:
             output += f"{colored(str(outcome_counts[TestOutcome.PASS]) + ' passed', color='green')}"
+        if outcome_counts[TestOutcome.DRYRUN]:
+            output += f"{colored(str(outcome_counts[TestOutcome.DRYRUN]) + ' printed', color='green')}"
 
         if test_results:
             output += " ] "
@@ -478,15 +481,20 @@ class SimpleTestResultWrite(TestResultWriterBase):
             for line in captured_stdout_lines:
                 print(indent(line, DOUBLE_INDENT))
 
-    def generate_chart(self, num_passed, num_failed, num_skipped, num_xfail, num_unexp):
-        num_tests = num_passed + num_failed + num_skipped + num_xfail + num_unexp
+    def generate_chart(
+        self, num_passed, num_failed, num_skipped, num_xfail, num_unexp, num_printed
+    ):
+        num_tests = (
+            num_passed + num_failed + num_skipped + num_xfail + num_unexp + num_printed
+        )
         pass_pct = num_passed / max(num_tests, 1)
         fail_pct = num_failed / max(num_tests, 1)
         xfail_pct = num_xfail / max(num_tests, 1)
         unexp_pct = num_unexp / max(num_tests, 1)
-        skip_pct = 1.0 - pass_pct - fail_pct - xfail_pct - unexp_pct
+        printed_pct = num_printed / max(num_tests, 1)
+        skip_pct = 1.0 - pass_pct - fail_pct - xfail_pct - unexp_pct - printed_pct
 
-        num_green_bars = int(pass_pct * self.terminal_size.width)
+        num_green_bars = int((pass_pct + printed_pct) * self.terminal_size.width)
         num_red_bars = int(fail_pct * self.terminal_size.width)
         num_blue_bars = int(skip_pct * self.terminal_size.width)
         num_yellow_bars = int(unexp_pct * self.terminal_size.width)
@@ -558,6 +566,9 @@ class SimpleTestResultWrite(TestResultWriterBase):
             TestOutcome.XPASS: len(
                 [r for r in test_results if r.outcome == TestOutcome.XPASS]
             ),
+            TestOutcome.DRYRUN: len(
+                [r for r in test_results if r.outcome == TestOutcome.DRYRUN]
+            ),
         }
 
 
@@ -568,6 +579,7 @@ def outcome_to_colour(outcome: TestOutcome) -> str:
         TestOutcome.FAIL: "red",
         TestOutcome.XFAIL: "magenta",
         TestOutcome.XPASS: "yellow",
+        TestOutcome.DRYRUN: "green",
     }[outcome]
 
 

--- a/ward/testing.py
+++ b/ward/testing.py
@@ -107,7 +107,7 @@ class Test:
     ward_meta: WardMeta = field(default_factory=WardMeta)
     timer: Optional["Timer"] = None
 
-    def run(self, cache: FixtureCache, idx: int = 0) -> "TestResult":
+    def run(self, cache: FixtureCache, idx: int = 0, dry_run=False) -> "TestResult":
 
         with ExitStack() as stack:
             self.timer = stack.enter_context(Timer())
@@ -128,6 +128,10 @@ class Test:
                     cache, iteration=self.param_meta.instance_index
                 )
                 self.format_description(resolved_args)
+                if dry_run:
+                    with closing(self.sout), closing(self.serr):
+                        result = TestResult(self, TestOutcome.DRYRUN)
+                    return result
                 self.fn(**resolved_args)
             except FixtureError as e:
                 outcome = TestOutcome.FAIL
@@ -457,6 +461,7 @@ class TestOutcome(Enum):
     SKIP = auto()
     XFAIL = auto()  # expected fail
     XPASS = auto()  # unexpected pass
+    DRYRUN = auto()
 
 
 @dataclass

--- a/ward/testing.py
+++ b/ward/testing.py
@@ -120,6 +120,11 @@ class Test:
                     result = TestResult(self, TestOutcome.SKIP)
                 return result
 
+            if dry_run:
+                with closing(self.sout), closing(self.serr):
+                    result = TestResult(self, TestOutcome.DRYRUN)
+                return result
+
             try:
                 # TODO:onlyanegg: I don't love this. We're setting up the
                 # fixture within the testing module, but cleaning it up in the
@@ -128,10 +133,6 @@ class Test:
                     cache, iteration=self.param_meta.instance_index
                 )
                 self.format_description(resolved_args)
-                if dry_run:
-                    with closing(self.sout), closing(self.serr):
-                        result = TestResult(self, TestOutcome.DRYRUN)
-                    return result
                 self.fn(**resolved_args)
             except FixtureError as e:
                 outcome = TestOutcome.FAIL


### PR DESCRIPTION
This is a solution for #129.

I went with green for the dry-run output. It does not collide with the PASS output because only SKIP and DRYR can occur when ward is run with the `--dry-run` option.

![image](https://user-images.githubusercontent.com/10177001/75115345-d5f87a80-565d-11ea-9afe-88b9f7538673.png)
