### PR TITLE
Use pprintpp to generate reprs instead of pprint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requires = [
     "click>=7.0",
     "toml>=0.9.4",
     "pygments>=2.4.2",
+    "pprintpp>=0.4.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ termcolor>=1.1.0
 dataclasses>=0.1; python_version < '3.7'
 click>=7.0
 toml>=0.9.4
+pprintpp==0.4.0

--- a/ward/diff.py
+++ b/ward/diff.py
@@ -1,6 +1,6 @@
 import difflib
-import pprint
 
+import pprintpp
 from colorama import Style, Fore
 from termcolor import colored
 
@@ -10,12 +10,12 @@ def make_diff(lhs, rhs, width=60) -> str:
     if isinstance(lhs, str):
         lhs_repr = lhs
     else:
-        lhs_repr = pprint.pformat(lhs, width=width)
+        lhs_repr = pprintpp.pformat(lhs, width=width)
 
     if isinstance(rhs, str):
         rhs_repr = rhs
     else:
-        rhs_repr = pprint.pformat(rhs, width=width)
+        rhs_repr = pprintpp.pformat(rhs, width=width)
 
     return build_unified_diff(lhs_repr, rhs_repr)
 
@@ -78,7 +78,7 @@ def build_unified_diff(lhs_repr, rhs_repr) -> str:
                         current_span = ""
                     current_span += line_to_rewrite[
                         index - 2
-                    ]  # Subtract 2 to account for code at start of line
+                        ]  # Subtract 2 to account for code at start of line
                 prev_char = char
                 index += 1
 


### PR DESCRIPTION
Using `pprintpp` to generate reprs which are diffed rather than `pprint`. `pprintpp` generates nicer output and aims for pep8 compliance.