### PR TITLE
Supporting Ward on CI: Add --show-symbols

### DIFF
--- a/ward/diff.py
+++ b/ward/diff.py
@@ -107,7 +107,7 @@ def build_unified_diff(lhs_repr: str, rhs_repr: str) -> str:
                         current_span = ""
                     current_span += line_to_rewrite[
                         index - 2
-                        ]  # Subtract 2 to account for code at start of line
+                    ]  # Subtract 2 to account for code at start of line
                 prev_char = char
                 index += 1
 

--- a/ward/diff.py
+++ b/ward/diff.py
@@ -45,12 +45,17 @@ def build_symbolic_unified_diff(lhs_repr: str, rhs_repr: str) -> str:
     for line_idx, line in enumerate(diff):
         if line.startswith("- "):
             last_line_colour = "green"
-            output_lines.append(colored(f"- {line[2:]}", color=last_line_colour))
+            output_lines.append(colored(f"+ {line[2:]}", color=last_line_colour))
         elif line.startswith("+ "):
             last_line_colour = "red"
-            output_lines.append(colored(f"+ {line[2:]}", color=last_line_colour))
+            output_lines.append(colored(f"- {line[2:]}", color=last_line_colour))
         elif line.startswith("? "):
-            output_lines.append(colored(line[:-1], color=last_line_colour))
+            output_line = line[:-1]
+            if last_line_colour == "red":
+                output_line = output_line.replace("+", "-")
+            elif last_line_colour == "green":
+                output_line = output_line.replace("-", "+")
+            output_lines.append(colored(output_line, color=last_line_colour))
         else:
             output_lines.append(line)
     return "\n".join(output_lines)
@@ -102,7 +107,7 @@ def build_unified_diff(lhs_repr: str, rhs_repr: str) -> str:
                         current_span = ""
                     current_span += line_to_rewrite[
                         index - 2
-                    ]  # Subtract 2 to account for code at start of line
+                        ]  # Subtract 2 to account for code at start of line
                 prev_char = char
                 index += 1
 

--- a/ward/diff.py
+++ b/ward/diff.py
@@ -45,10 +45,10 @@ def build_symbolic_unified_diff(lhs_repr: str, rhs_repr: str) -> str:
     for line_idx, line in enumerate(diff):
         if line.startswith("- "):
             last_line_colour = "green"
-            output_lines.append(colored(line, color=last_line_colour))
+            output_lines.append(colored(f"+ {line[2:]}", color=last_line_colour))
         elif line.startswith("+ "):
             last_line_colour = "red"
-            output_lines.append(colored(line, color=last_line_colour))
+            output_lines.append(colored(f"- {line[2:]}", color=last_line_colour))
         elif line.startswith("? "):
             output_lines.append(colored(line[:-1], color=last_line_colour))
         else:

--- a/ward/diff.py
+++ b/ward/diff.py
@@ -1,11 +1,12 @@
 import difflib
+from typing import Generator
 
 import pprintpp
 from colorama import Style, Fore
 from termcolor import colored
 
 
-def make_diff(lhs, rhs, width=60) -> str:
+def make_diff(lhs, rhs, width=80, show_symbols=False) -> str:
     """Transform input into best format for diffing, then return output diff."""
     if isinstance(lhs, str):
         lhs_repr = lhs
@@ -17,6 +18,8 @@ def make_diff(lhs, rhs, width=60) -> str:
     else:
         rhs_repr = pprintpp.pformat(rhs, width=width)
 
+    if show_symbols:
+        return build_symbolic_unified_diff(lhs_repr, rhs_repr)
     return build_unified_diff(lhs_repr, rhs_repr)
 
 
@@ -28,12 +31,33 @@ def bright_green(s: str) -> str:
     return f"{Fore.LIGHTGREEN_EX}{s}{Style.RESET_ALL}"
 
 
-def build_unified_diff(lhs_repr, rhs_repr) -> str:
+def raw_unified_diff(lhs_repr: str, rhs_repr: str) -> Generator[str, None, None]:
     differ = difflib.Differ()
     lines_lhs = lhs_repr.splitlines()
     lines_rhs = rhs_repr.splitlines()
-    diff = differ.compare(lines_lhs, lines_rhs)
+    return differ.compare(lines_lhs, lines_rhs)
 
+
+def build_symbolic_unified_diff(lhs_repr: str, rhs_repr: str) -> str:
+    diff = raw_unified_diff(lhs_repr, rhs_repr)
+    output_lines = []
+    last_line_colour = "grey"
+    for line_idx, line in enumerate(diff):
+        if line.startswith("- "):
+            last_line_colour = "green"
+            output_lines.append(colored(line, color=last_line_colour))
+        elif line.startswith("+ "):
+            last_line_colour = "red"
+            output_lines.append(colored(line, color=last_line_colour))
+        elif line.startswith("? "):
+            output_lines.append(colored(line[:-1], color=last_line_colour))
+        else:
+            output_lines.append(line)
+    return "\n".join(output_lines)
+
+
+def build_unified_diff(lhs_repr: str, rhs_repr: str) -> str:
+    diff = raw_unified_diff(lhs_repr, rhs_repr)
     output_lines = []
     prev_marker = ""
     for line_idx, line in enumerate(diff):

--- a/ward/run.py
+++ b/ward/run.py
@@ -1,13 +1,14 @@
 import sys
 from pathlib import Path
 from timeit import default_timer
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import click
 from click_default_group import DefaultGroup
 from colorama import init
 from cucumber_tag_expressions import parse as parse_tags
 from cucumber_tag_expressions.model import Expression
+
 from ward._ward_version import __version__
 from ward.collect import (
     get_info_for_modules,
@@ -101,7 +102,7 @@ exclude = click.option(
     help="Paths to ignore while searching for tests. Accepts glob patterns.",
 )
 @click.option(
-    "--show-symbols/--hide-symbols",
+    "--show-diff-symbols/--hide-diff-symbols",
     default=False,
     help="If enabled, diffs will use symbols such as '?', '-', '+' and '^' instead of colours to highlight differences.",
 )
@@ -136,7 +137,7 @@ def test(
     order: str,
     capture_output: bool,
     show_slowest: int,
-    show_symbols: bool,
+    show_diff_symbols: bool,
     dry_run: bool,
 ):
     """Run tests."""
@@ -159,7 +160,7 @@ def test(
         suite=suite,
         test_output_style=test_output_style,
         config_path=config_path,
-        show_diff_symbols=show_symbols,
+        show_diff_symbols=show_diff_symbols,
     )
     writer.output_header(time_to_collect=time_to_collect)
 

--- a/ward/run.py
+++ b/ward/run.py
@@ -60,6 +60,11 @@ sys.path.append(".")
     help="Paths to ignore while searching for tests. Accepts glob patterns.",
 )
 @click.option(
+    "--show-symbols/--hide-symbols",
+    default=False,
+    help="If enabled, diffs will use symbols such as '?', '-', '+' and '^' instead of colours to highlight differences.",
+)
+@click.option(
     "--capture-output/--no-capture-output",
     default=True,
     help="Enable or disable output capturing.",
@@ -107,6 +112,7 @@ def run(
     config: str,
     config_path: Optional[Path],
     show_slowest: int,
+    show_symbols: bool,
     dry_run: bool,
 ):
     start_run = default_timer()
@@ -125,7 +131,10 @@ def run(
     test_results = suite.generate_test_runs(order=order, dry_run=dry_run)
 
     writer = SimpleTestResultWrite(
-        suite=suite, test_output_style=test_output_style, config_path=config_path,
+        suite=suite,
+        test_output_style=test_output_style,
+        config_path=config_path,
+        show_diff_symbols=show_symbols,
     )
     results = writer.output_all_test_results(
         test_results, time_to_collect=time_to_collect, fail_limit=fail_limit

--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -224,11 +224,16 @@ class TestResultWriterBase:
     }
 
     def __init__(
-        self, suite: Suite, test_output_style: str, config_path: Optional[Path]
+        self,
+        suite: Suite,
+        test_output_style: str,
+        config_path: Optional[Path],
+        show_diff_symbols: bool = False,
     ):
         self.suite = suite
         self.test_output_style = test_output_style
         self.config_path = config_path
+        self.show_diff_symbols = show_diff_symbols
         self.terminal_size = get_terminal_size()
 
     def output_all_test_results(
@@ -385,7 +390,12 @@ class SimpleTestResultWrite(TestResultWriterBase):
             f" vs {colored('RHS', color='red')} shown below\n"
         )
         print(indent(diff_msg, INDENT))
-        diff = make_diff(err.lhs, err.rhs, width=self.terminal_size.width - 24)
+        diff = make_diff(
+            err.lhs,
+            err.rhs,
+            width=self.terminal_size.width - 24,
+            show_symbols=self.show_diff_symbols,
+        )
         print(indent(diff, DOUBLE_INDENT))
 
     def print_traceback(self, err):


### PR DESCRIPTION
To enable Ward to run on CI systems and to aid those with difficulties viewing differences between colours, adds the option to use a more traditional "symbolic" unified diff:

![Screenshot 2020-03-13 at 19 51 38](https://user-images.githubusercontent.com/5740731/76655146-976f2500-6564-11ea-8d74-ff04bdb7f77a.png)

To use symbols instead of colour highlighting call `ward --show-symbols` or add `show_symbols = true` to `pyproject.toml`.
