### PR TITLE
Add CLI command to show fixture information

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -112,7 +112,7 @@ description = "Utility library for gitignore style pattern matching of file path
 name = "pathspec"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.7.0"
+version = "0.8.0"
 
 [[package]]
 category = "main"
@@ -152,7 +152,7 @@ description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.2.20"
+version = "2020.4.4"
 
 [[package]]
 category = "main"
@@ -223,8 +223,8 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 pathspec = [
-    {file = "pathspec-0.7.0-py2.py3-none-any.whl", hash = "sha256:163b0632d4e31cef212976cf57b43d9fd6b0bac6e67c26015d611a647d5e7424"},
-    {file = "pathspec-0.7.0.tar.gz", hash = "sha256:562aa70af2e0d434367d9790ad37aed893de47f1693e4201fd1d3dca15d19b96"},
+    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
+    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
 ]
 pprintpp = [
     {file = "pprintpp-0.4.0-py2.py3-none-any.whl", hash = "sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d"},
@@ -243,27 +243,27 @@ pygments = [
     {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
 ]
 regex = [
-    {file = "regex-2020.2.20-cp27-cp27m-win32.whl", hash = "sha256:99272d6b6a68c7ae4391908fc15f6b8c9a6c345a46b632d7fdb7ef6c883a2bbb"},
-    {file = "regex-2020.2.20-cp27-cp27m-win_amd64.whl", hash = "sha256:974535648f31c2b712a6b2595969f8ab370834080e00ab24e5dbb9d19b8bfb74"},
-    {file = "regex-2020.2.20-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5de40649d4f88a15c9489ed37f88f053c15400257eeb18425ac7ed0a4e119400"},
-    {file = "regex-2020.2.20-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:82469a0c1330a4beb3d42568f82dffa32226ced006e0b063719468dcd40ffdf0"},
-    {file = "regex-2020.2.20-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d58a4fa7910102500722defbde6e2816b0372a4fcc85c7e239323767c74f5cbc"},
-    {file = "regex-2020.2.20-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f1ac2dc65105a53c1c2d72b1d3e98c2464a133b4067a51a3d2477b28449709a0"},
-    {file = "regex-2020.2.20-cp36-cp36m-win32.whl", hash = "sha256:8c2b7fa4d72781577ac45ab658da44c7518e6d96e2a50d04ecb0fd8f28b21d69"},
-    {file = "regex-2020.2.20-cp36-cp36m-win_amd64.whl", hash = "sha256:269f0c5ff23639316b29f31df199f401e4cb87529eafff0c76828071635d417b"},
-    {file = "regex-2020.2.20-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:bed7986547ce54d230fd8721aba6fd19459cdc6d315497b98686d0416efaff4e"},
-    {file = "regex-2020.2.20-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:046e83a8b160aff37e7034139a336b660b01dbfe58706f9d73f5cdc6b3460242"},
-    {file = "regex-2020.2.20-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b33ebcd0222c1d77e61dbcd04a9fd139359bded86803063d3d2d197b796c63ce"},
-    {file = "regex-2020.2.20-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bba52d72e16a554d1894a0cc74041da50eea99a8483e591a9edf1025a66843ab"},
-    {file = "regex-2020.2.20-cp37-cp37m-win32.whl", hash = "sha256:01b2d70cbaed11f72e57c1cfbaca71b02e3b98f739ce33f5f26f71859ad90431"},
-    {file = "regex-2020.2.20-cp37-cp37m-win_amd64.whl", hash = "sha256:113309e819634f499d0006f6200700c8209a2a8bf6bd1bdc863a4d9d6776a5d1"},
-    {file = "regex-2020.2.20-cp38-cp38-manylinux1_i686.whl", hash = "sha256:25f4ce26b68425b80a233ce7b6218743c71cf7297dbe02feab1d711a2bf90045"},
-    {file = "regex-2020.2.20-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:9b64a4cc825ec4df262050c17e18f60252cdd94742b4ba1286bcfe481f1c0f26"},
-    {file = "regex-2020.2.20-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:9ff16d994309b26a1cdf666a6309c1ef51ad4f72f99d3392bcd7b7139577a1f2"},
-    {file = "regex-2020.2.20-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:c7f58a0e0e13fb44623b65b01052dae8e820ed9b8b654bb6296bc9c41f571b70"},
-    {file = "regex-2020.2.20-cp38-cp38-win32.whl", hash = "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d"},
-    {file = "regex-2020.2.20-cp38-cp38-win_amd64.whl", hash = "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa"},
-    {file = "regex-2020.2.20.tar.gz", hash = "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5"},
+    {file = "regex-2020.4.4-cp27-cp27m-win32.whl", hash = "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f"},
+    {file = "regex-2020.4.4-cp27-cp27m-win_amd64.whl", hash = "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3"},
+    {file = "regex-2020.4.4-cp36-cp36m-win32.whl", hash = "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8"},
+    {file = "regex-2020.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948"},
+    {file = "regex-2020.4.4-cp37-cp37m-win32.whl", hash = "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e"},
+    {file = "regex-2020.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"},
+    {file = "regex-2020.4.4-cp38-cp38-win32.whl", hash = "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3"},
+    {file = "regex-2020.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3"},
+    {file = "regex-2020.4.4.tar.gz", hash = "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142"},
 ]
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -50,6 +50,17 @@ version = "7.1.1"
 
 [[package]]
 category = "main"
+description = "Extends click.Group to invoke a command without explicit subcommand name"
+name = "click-default-group"
+optional = false
+python-versions = "*"
+version = "1.2.2"
+
+[package.dependencies]
+click = "*"
+
+[[package]]
+category = "main"
 description = "Cross-platform colored terminal text."
 name = "colorama"
 optional = false
@@ -179,7 +190,7 @@ python-versions = "*"
 version = "1.4.1"
 
 [metadata]
-content-hash = "592c887b2b8ed2c3967a9aabfbc62566efc266170f3aff6404190c8a439530f2"
+content-hash = "0c8a5ac3b90d4f4ecca09846c4cf2915aacc583132b247e9c4832c634b133504"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -198,6 +209,9 @@ black = [
 click = [
     {file = "click-7.1.1-py2.py3-none-any.whl", hash = "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"},
     {file = "click-7.1.1.tar.gz", hash = "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"},
+]
+click-default-group = [
+    {file = "click-default-group-1.2.2.tar.gz", hash = "sha256:d9560e8e8dfa44b3562fbc9425042a0fd6d21956fcc2db0077f63f34253ab904"},
 ]
 colorama = [
     {file = "colorama-0.3.9-py2.py3-none-any.whl", hash = "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ toml = "^0.9.4"
 pygments = "^2.4.2"
 pprintpp = "^0.4.0"
 cucumber-tag-expressions = "^2.0.0"
+click-default-group = "^1.2.2"
 
 [tool.poetry.dev-dependencies]
 black = "^19.9b0"

--- a/ward/fixtures.py
+++ b/ward/fixtures.py
@@ -35,6 +35,10 @@ class Fixture:
         return self.fn.ward_meta.path
 
     @property
+    def line_number(self) -> int:
+        return inspect.getsourcelines(self.fn)[1]
+
+    @property
     def is_generator_fixture(self):
         return inspect.isgeneratorfunction(inspect.unwrap(self.fn))
 
@@ -131,6 +135,9 @@ class FixtureCache:
         return fixtures.get(fixture_key)
 
 
+FIXTURES = []
+
+
 def fixture(func=None, *, scope: Optional[Union[Scope, str]] = Scope.Test):
     if not isinstance(scope, Scope):
         scope = Scope.from_str(scope)
@@ -147,6 +154,8 @@ def fixture(func=None, *, scope: Optional[Union[Scope, str]] = Scope.Test):
         func.ward_meta.path = path
     else:
         func.ward_meta = WardMeta(is_fixture=True, scope=scope, path=path)
+
+    FIXTURES.append(func)
 
     @wraps(func)
     def wrapper(*args, **kwargs):

--- a/ward/fixtures.py
+++ b/ward/fixtures.py
@@ -135,7 +135,7 @@ class FixtureCache:
         return fixtures.get(fixture_key)
 
 
-FIXTURES = []
+_FIXTURES = []
 
 
 def fixture(func=None, *, scope: Optional[Union[Scope, str]] = Scope.Test):
@@ -155,7 +155,7 @@ def fixture(func=None, *, scope: Optional[Union[Scope, str]] = Scope.Test):
     else:
         func.ward_meta = WardMeta(is_fixture=True, scope=scope, path=path)
 
-    FIXTURES.append(func)
+    _FIXTURES.append(func)
 
     @wraps(func)
     def wrapper(*args, **kwargs):

--- a/ward/run.py
+++ b/ward/run.py
@@ -17,7 +17,6 @@ from ward.collect import (
 from ward.config import set_defaults_from_config
 from ward.rewrite import rewrite_assertions_in_tests
 from ward.suite import Suite
-from ward.fixtures import FIXTURES
 from ward.terminal import SimpleTestResultWrite, output_fixtures, get_exit_code
 
 init()
@@ -134,10 +133,10 @@ def run(
     writer = SimpleTestResultWrite(
         suite=suite, test_output_style=test_output_style, config_path=config_path,
     )
-    writer.output_header(time_to_collect=time_to_collect, num_fixtures=len(FIXTURES))
+    writer.output_header(time_to_collect=time_to_collect)
 
     if fixtures:
-        output_fixtures(FIXTURES)
+        output_fixtures()
         sys.exit(0)
 
     results = writer.output_all_test_results(test_results, fail_limit=fail_limit)

--- a/ward/run.py
+++ b/ward/run.py
@@ -156,8 +156,28 @@ def test(
 @path
 @exclude
 @click.option(
+    "--show-scopes/--no-show-scopes",
+    help="Display each fixture's scope.",
+    default=True,
+)
+@click.option(
     "--show-docstrings/--no-show-docstrings",
-    help="Print each fixture's docstring",
+    help="Display each fixture's docstring.",
+    default=False,
+)
+@click.option(
+    "--show-direct-dependencies/--no-show-direct-dependencies",
+    help="Display the fixtures that each fixture depends on directly.",
+    default=False,
+)
+@click.option(
+    "--show-dependency-trees/--no-show-dependency-trees",
+    help="Display the entire dependency tree for each fixture.",
+    default=False,
+)
+@click.option(
+    "--full/--no-full",
+    help="Display all available information on each fixture.",
     default=False,
 )
 @click.pass_context
@@ -167,11 +187,20 @@ def fixtures(
     config_path: Optional[Path],
     path: Tuple[str],
     exclude: Tuple[str],
+    show_scopes: bool,
     show_docstrings: bool,
+    show_direct_dependencies: bool,
+    show_dependency_trees: bool,
+    full: bool,
 ):
     """Show information on fixtures."""
     paths = [Path(p) for p in path]
     mod_infos = get_info_for_modules(paths, exclude)
     modules = list(load_modules(mod_infos))
 
-    output_fixtures(show_docstrings=show_docstrings)
+    output_fixtures(
+        show_scopes=show_scopes or full,
+        show_docstrings=show_docstrings or full,
+        show_direct_dependencies=show_direct_dependencies or full,
+        show_dependency_trees=show_dependency_trees or full,
+    )

--- a/ward/run.py
+++ b/ward/run.py
@@ -4,6 +4,7 @@ from timeit import default_timer
 from typing import List, Optional, Tuple
 
 import click
+from click_default_group import DefaultGroup
 from colorama import init
 from cucumber_tag_expressions import parse as parse_tags
 from cucumber_tag_expressions.model import Expression
@@ -24,11 +25,16 @@ init()
 sys.path.append(".")
 
 
-@click.group(context_settings={"max_content_width": 100}, invoke_without_command=True)
+# TODO: simplify to use invoke_without_command and ctx.forward once https://github.com/pallets/click/issues/430 is resolved
+@click.group(
+    context_settings={"max_content_width": 100},
+    cls=DefaultGroup,
+    default="test",
+    default_if_no_args=True,
+)
 @click.pass_context
 def run(ctx: click.Context):
-    if ctx.invoked_subcommand is None:
-        ctx.forward(test)
+    pass
 
 
 config = click.option(

--- a/ward/run.py
+++ b/ward/run.py
@@ -17,7 +17,8 @@ from ward.collect import (
 from ward.config import set_defaults_from_config
 from ward.rewrite import rewrite_assertions_in_tests
 from ward.suite import Suite
-from ward.terminal import SimpleTestResultWrite, get_exit_code
+from ward.fixtures import FIXTURES
+from ward.terminal import SimpleTestResultWrite, output_fixtures, get_exit_code
 
 init()
 
@@ -93,6 +94,11 @@ sys.path.append(".")
     help="Print all tests without executing them",
     default=False,
 )
+@click.option(
+    "--fixtures/--no-fixtures",
+    help="Display information on fixtures (and do not execute tests)",
+    default=False,
+)
 @click.pass_context
 def run(
     ctx: click.Context,
@@ -108,6 +114,7 @@ def run(
     config_path: Optional[Path],
     show_slowest: int,
     dry_run: bool,
+    fixtures: bool,
 ):
     start_run = default_timer()
     paths = [Path(p) for p in path]
@@ -127,9 +134,13 @@ def run(
     writer = SimpleTestResultWrite(
         suite=suite, test_output_style=test_output_style, config_path=config_path,
     )
-    results = writer.output_all_test_results(
-        test_results, time_to_collect=time_to_collect, fail_limit=fail_limit
-    )
+    writer.output_header(time_to_collect=time_to_collect, num_fixtures=len(FIXTURES))
+
+    if fixtures:
+        output_fixtures(FIXTURES)
+        sys.exit(0)
+
+    results = writer.output_all_test_results(test_results, fail_limit=fail_limit)
     time_taken = default_timer() - start_run
     writer.output_test_result_summary(results, time_taken, show_slowest)
 

--- a/ward/run.py
+++ b/ward/run.py
@@ -52,13 +52,13 @@ path = click.option(
     type=click.Path(exists=True),
     multiple=True,
     is_eager=True,
-    help="Look for tests in PATH.",
+    help="Look for items in PATH.",
 )
 exclude = click.option(
     "--exclude",
     type=click.STRING,
     multiple=True,
-    help="Paths to ignore while searching for tests. Accepts glob patterns.",
+    help="Paths to ignore while searching for items. Accepts glob patterns.",
 )
 
 

--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -565,7 +565,7 @@ def output_fixture_information(fixture):
 
 
 def format_fixture_header(fixture):
-    path = lightblack(f"{fixture.path.name}::{fixture.line_number}")
+    path = lightblack(f"{fixture.path.name}:{fixture.line_number}")
     name = colored(fixture.name, color="cyan", attrs=["bold"])
     scope = colored(
         fixture.scope.value, color=scope_to_colour(fixture.scope), attrs=["bold"]

--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -625,7 +625,7 @@ def output_fixture_dependency_tree(
 
 
 def format_fixture_header(fixture: Fixture, show_scopes: bool):
-    path = lightblack(f"{fixture.path.name}::{fixture.line_number}")
+    path = lightblack(f"{fixture.path.name}:{fixture.line_number}")
     name = colored(fixture.name, color="cyan", attrs=["bold"])
     scope = colored(
         fixture.scope.value, color=scope_to_colour(fixture.scope), attrs=["bold"]

--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -20,7 +20,7 @@ from ward.diff import make_diff
 from ward.expect import Comparison, TestFailure
 from ward.suite import Suite
 from ward.testing import TestOutcome, TestResult
-from ward.fixtures import Fixture, Scope
+from ward.fixtures import Fixture, Scope, FIXTURES
 
 INDENT = " " * 2
 DOUBLE_INDENT = INDENT * 2
@@ -232,7 +232,7 @@ class TestResultWriterBase:
         self.config_path = config_path
         self.terminal_size = get_terminal_size()
 
-    def output_header(self, time_to_collect, num_fixtures):
+    def output_header(self, time_to_collect):
         python_impl = platform.python_implementation()
         python_version = platform.python_version()
         print(f"Ward {__version__}, {python_impl} {python_version}")
@@ -244,7 +244,7 @@ class TestResultWriterBase:
             print(f"Using config from {path}")
         print(
             f"Collected {self.suite.num_tests} tests "
-            f"and {num_fixtures} fixtures "
+            f"and {len(FIXTURES)} fixtures "
             f"in {time_to_collect:.2f} seconds."
         )
 
@@ -536,8 +536,8 @@ def scope_to_colour(scope: Scope) -> str:
     return {Scope.Test: "green", Scope.Module: "blue", Scope.Global: "magenta",}[scope]
 
 
-def output_fixtures(fixtures):
-    fixtures = [Fixture(f) for f in fixtures]
+def output_fixtures():
+    fixtures = [Fixture(f) for f in FIXTURES]
 
     for fixture in fixtures:
         output_fixture_information(fixture)

--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -20,7 +20,7 @@ from ward.diff import make_diff
 from ward.expect import Comparison, TestFailure
 from ward.suite import Suite
 from ward.testing import TestOutcome, TestResult
-from ward.fixtures import Fixture, Scope, FIXTURES
+from ward.fixtures import Fixture, Scope, _FIXTURES
 
 INDENT = " " * 2
 DOUBLE_INDENT = INDENT * 2
@@ -244,7 +244,7 @@ class TestResultWriterBase:
             print(f"Using config from {path}")
         print(
             f"Collected {self.suite.num_tests} tests "
-            f"and {len(FIXTURES)} fixtures "
+            f"and {len(_FIXTURES)} fixtures "
             f"in {time_to_collect:.2f} seconds."
         )
 
@@ -537,7 +537,7 @@ def scope_to_colour(scope: Scope) -> str:
 
 
 def output_fixtures():
-    fixtures = [Fixture(f) for f in FIXTURES]
+    fixtures = [Fixture(f) for f in _FIXTURES]
 
     for fixture in fixtures:
         output_fixture_information(fixture)

--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -536,14 +536,14 @@ def scope_to_colour(scope: Scope) -> str:
     return {Scope.Test: "green", Scope.Module: "blue", Scope.Global: "magenta",}[scope]
 
 
-def output_fixtures():
+def output_fixtures(show_docstrings: bool):
     fixtures = [Fixture(f) for f in _FIXTURES]
 
     for fixture in fixtures:
-        output_fixture_information(fixture)
+        output_fixture_information(fixture, show_docstring=show_docstrings)
 
 
-def output_fixture_information(fixture):
+def output_fixture_information(fixture: Fixture, show_docstring: bool):
     deps = [
         format_fixture_header(Fixture(par.default)) for par in fixture.deps().values()
     ]
@@ -554,7 +554,7 @@ def output_fixture_information(fixture):
         lines.append(indent(f"depends on", INDENT))
         lines.extend(indent("\n".join(deps), DOUBLE_INDENT).splitlines())
 
-    if fixture.fn.__doc__ is not None:
+    if show_docstring and fixture.fn.__doc__ is not None:
         doc = dedent(fixture.fn.__doc__)
         lines.extend(indent(f"{doc}", INDENT).splitlines())
 

--- a/ward/tests/test_fixtures.py
+++ b/ward/tests/test_fixtures.py
@@ -65,8 +65,11 @@ def my_test(
     f3=module_fixture,
     f4=default_fixture,
 ):
-    # Inject these fixtures into a test, and resolve them
-    # to ensure they're ready to be torn down.
+    """
+    Inject these fixtures into a test, and resolve them
+    to ensure they're ready to be torn down.
+    """
+
     @testable_test
     def t(f1=f1, f2=f2, f3=f3, f4=f4):
         pass


### PR DESCRIPTION
(I was up too late and decided to take a crack at #151 ; apologies for not poking that issue in advance. This is my first time looking at Ward, so please let me know if this implementation is just bogus given other design considerations!)

This PR adds a CLI option `--fixtures` that a) prevents tests from executing at all (it does not even print them like in a dry run) and b) prints out information on all defined fixtures. The output from ward's own suite looks like this (I took the liberty of turning an unrelated comment in a fixture into a docstring to show what it would look like):

![image](https://user-images.githubusercontent.com/7133863/80299390-992e2a00-8759-11ea-9787-03acc50aa754.png)

The simplest way to wire this up was to store off fixture functions to a module-level list in every invocation of the `fixture` decorator. This goes against the "don't look at fixtures until we run tests" note in #151 . However, it could enable other run options where Ward does this collection step, then runs the tests and print out more annotations on the fixtures, namely which/how many tests actually used them. I see some value in this kind of lightweight introspection to identify all defined fixtures, regardless of whether they're used or not (and it still obeys the less-strict statement "only look at fixtures that are imported by the test suite").

No tests yet, because I wasn't sure how you would want this kind of CLI output tested.