### PR TITLE
Ensure that incorrectly parameterised tests fail as expected

### DIFF
--- a/ward/run.py
+++ b/ward/run.py
@@ -163,7 +163,6 @@ def test(
         show_diff_symbols=show_diff_symbols,
     )
     writer.output_header(time_to_collect=time_to_collect)
-
     results = writer.output_all_test_results(test_results, fail_limit=fail_limit)
     time_taken = default_timer() - start_run
     writer.output_test_result_summary(results, time_taken, show_slowest)

--- a/ward/terminal.py
+++ b/ward/terminal.py
@@ -18,7 +18,6 @@ from termcolor import colored, cprint
 from ward._ward_version import __version__
 from ward.diff import make_diff
 from ward.expect import Comparison, TestFailure
-from ward.suite import Suite
 from ward.testing import TestOutcome, TestResult
 from ward.fixtures import Fixture, Scope, _FIXTURES
 
@@ -232,7 +231,7 @@ class TestResultWriterBase:
 
     def __init__(
         self,
-        suite: Suite,
+        suite,
         test_output_style: str,
         config_path: Optional[Path],
         show_diff_symbols: bool = False,

--- a/ward/testing.py
+++ b/ward/testing.py
@@ -177,6 +177,11 @@ class Test:
 
         return result
 
+    def fail_with_error(self, error: Exception) -> "TestResult":
+        return TestResult(
+            self, outcome=TestOutcome.FAIL, error=error, message=str(error)
+        )
+
     @property
     def name(self) -> str:
         return self.fn.__name__
@@ -322,7 +327,7 @@ class Test:
         is_valid = len(set(lengths)) in (0, 1)
         if not is_valid:
             raise ParameterisationError(
-                f"The test {self.name}/{self.description} is parameterised incorrectly. "
+                f"The test described by '{self.description}' is parameterised incorrectly. "
                 f"Please ensure all instances of 'each' in the test signature "
                 f"are of equal length."
             )


### PR DESCRIPTION
Fixes #162 issue where tests would not expand, not run, and not fail if parameterisation was incorrect.