### PR TITLE
Rewrite test functions with `lambda` in `each` correctly

### DIFF
--- a/ward/rewrite.py
+++ b/ward/rewrite.py
@@ -120,8 +120,13 @@ def rewrite_assertion(test: Test) -> Test:
     if test.fn.__closure__:
         clo_glob = test.fn.__closure__[0].cell_contents.__globals__
 
+    # Look through the new module,
+    # find the code object with the same name as the original code object,
+    # and build a new function with the injected assert functions added to the global namespace.
+    # Filtering on the code object name prevents finding other kinds of code objects,
+    # like lambdas stored directly in test function arguments.
     for const in new_mod_code_obj.co_consts:
-        if isinstance(const, types.CodeType):
+        if isinstance(const, types.CodeType) and const.co_name == code_obj.co_name:
             new_test_func = types.FunctionType(
                 const,
                 {**assert_func_namespace, **test.fn.__globals__, **clo_glob},

--- a/ward/tests/test_rewrite.py
+++ b/ward/tests/test_rewrite.py
@@ -187,3 +187,19 @@ if True:
         @test("test with indentation level of 2")
         def _():
             assert 2 + 3 == 5
+
+
+@test("rewriter finds correct function when there is a lambda in an each")
+def _():
+    @testable_test
+    def _(x=each(lambda: 5)):
+        assert x == 5
+
+    t = Test(fn=_, module_name="m")
+
+    rewritten = rewrite_assertions_in_tests([t])[0]
+
+    # https://github.com/darrenburns/ward/issues/169
+    # The assertion rewriter thought the lambda function stored in co_consts was the test function,
+    # so it was rebuilding the test function using the lambda as the test instead of the original function.
+    assert rewritten.fn.__code__.co_name != "<lambda>"


### PR DESCRIPTION
I think I figured out the problem behind #169 : this block of code https://github.com/darrenburns/ward/compare/master...JoshKarpel:lambdas-in-each?expand=1#diff-5bf3f78f564c6863fb8d1277927fc92ddb2a6cfaecbd155c2574bb797dd03138L123

I'm not totally sure what that block of code is supposed to do, but when you pass a `lambda` to an `each`, it ends up in `co_consts`, and the `if` triggers because a `lambda` is a `FunctionType`. The `Test`s function `fn` ends up being replaced with the first `lambda` function from the `each`. The resulting test is not parameterized (because it's `fn` is just some random `lambda`) and passes because it's just invoking the `lambda` function when run.

(This doesn't happen if you just have a default argument which is a `lambda`. I assume this is because when it's an argument, it becomes a constant in a constant tuple of positional arguments to `each`, but when it's just a bare argument, it's considered an argument, not a constant.)

It turns out that if you delete that entire block, the error goes away and no other tests start failing. I'm sure I'm missing something, but... maybe that's the fix?

I added a test case that catches this: https://github.com/darrenburns/ward/compare/master...JoshKarpel:lambdas-in-each?expand=1#diff-33a7b458f61ac2c69340d3ef50213e9c2e643d7ed4bdbaf077f5001c36030ec1R192

With this PR, 
```python
from ward import test, each

@test("{func} returns {value} via lambdas")
def _(func=each(lambda: None, lambda: 1), value=each(None, 1)):
    assert func() == value

def return_none():
    return None

def return_one():
    return 1

@test("{func} returns {value} via funcs")
def _(func=each(return_none, return_one), value=each(None, 1)):
    assert func() == value
```
produces (as expected)
```
 PASS  test_each:5[1/2] <function <lambda> at 0x7fb0bc973680> returns None via lambdas
 PASS  test_each:5[2/2] <function <lambda> at 0x7fb0bc973710> returns 1 via lambdas
 PASS  test_each:18[1/2] <function return_none at 0x7fb0bc10f710> returns None via funcs
 PASS  test_each:18[2/2] <function return_one at 0x7fb0bc973950> returns 1 via funcs
```

(`make prep` caused a bunch of diffs from `black`, like in #179 )