### PR TITLE
Add `dependabot.yml` for GHA version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I don't love how dependabot doesn't group updates, but I find it pretty convenient for bumping GitHub Actions versions since they don't change often and there aren't many of them, and it's outside of people's normal workflow to try to keep them in sync.

(Noticed that you had to do a bump for https://github.com/darrenburns/ward/pull/230)