### PR TITLE
Optimize assertion rewriting

### DIFF
--- a/ward/_rewrite.py
+++ b/ward/_rewrite.py
@@ -94,7 +94,9 @@ def rewrite_assertions_in_tests(tests: Iterable[Test]) -> List[Test]:
 
 def rewrite_assertion(test: Test) -> Test:
     # Get the old code and code object
-    code = inspect.getsource(test.fn)
+    code_lines, line_no = inspect.getsourcelines(test.fn)
+
+    code = "".join(code_lines)
     indents = textwrap._leading_whitespace_re.findall(code)
     col_offset = len(indents[0]) if len(indents) > 0 else 0
     code = textwrap.dedent(code)
@@ -102,7 +104,6 @@ def rewrite_assertion(test: Test) -> Test:
 
     # Rewrite the AST of the code
     tree = ast.parse(code)
-    line_no = inspect.getsourcelines(test.fn)[1]
     ast.increment_lineno(tree, line_no - 1)
 
     new_tree = RewriteAssert().visit(tree)


### PR DESCRIPTION
https://github.com/darrenburns/ward/blob/3bc5de8cf62c6e815bbda165f5b3a3a64d9090af/ward/_rewrite.py#L95 currently gets the test function's source code twice. Doing it only once cuts the rewrite time by ~1/2, and it turns out that this is a large fraction of the total runtime (at least on my machine, so this represents a fairly significant improvement.

```
# before
$  hyperfine ward
Benchmark #1: ward
  Time (mean ± σ):      2.850 s ±  0.082 s    [User: 1.188 s, System: 0.119 s]
  Range (min … max):    2.744 s …  2.995 s    10 runs

# after
$ hyperfine ward
Benchmark #1: ward
  Time (mean ± σ):      2.516 s ±  0.077 s    [User: 1.105 s, System: 0.099 s]
  Range (min … max):    2.403 s …  2.631 s    10 runs
```

(https://github.com/sharkdp/hyperfine ... I don't quite understand why User + System != total)