### PR TITLE
Fix typo in docs on parameterizing tests

### DIFF
--- a/docs/source/guide/writing_tests.rst
+++ b/docs/source/guide/writing_tests.rst
@@ -122,7 +122,7 @@ You can also make a reference to a fixture and Ward will resolve and inject it:
             assert left + right == result
 
 Ward also supports parameterised testing by allowing multiple fixtures or
-values to be bound as a keyword argument using the ```each`` function:
+values to be bound as a keyword argument using the ``each`` function:
 
 .. code-block:: python
 


### PR DESCRIPTION
A simple typo fix (remove an extra backtick)