### PR TITLE
Add pretty output for all comparison failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ ward = "ward._run:run"
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
+    "pragma: unreachable",
     "def __repr__",
     "raise AssertionError",
     "raise NotImplementedError",

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -15,11 +15,21 @@ from ward.testing import Test, each
 
 def as_dict(node: ast.AST):
     if isinstance(node, ast.AST):
-        return {
+        d = {
             k: as_dict(v)
             for k, v in vars(node).items()
-            if k not in {"lineno", "col_offset", "ctx", "end_lineno", "end_col_offset"}
+            if k
+            not in {
+                "lineno",
+                "col_offset",
+                "ctx",
+                "end_lineno",
+                "end_col_offset",
+                "kind",
+            }
         }
+        d["_type"] = type(node)
+        return d
     else:
         return node
 
@@ -124,6 +134,7 @@ for msg, expected in [
     (", 'msg'", ast.Str("msg")),
     (", 1", ast.Num(1)),
     (", 1 + 1", ast.BinOp(ast.Num(1), ast.Add(), ast.Num(1))),
+    (", 1 - 1", ast.BinOp(ast.Num(1), ast.Sub(), ast.Num(1))),
 ]:
 
     @test("get_assertion_message({src}) returns '{msg}'")

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -119,14 +119,18 @@ def _(src="assert 1 == 2, 'msg'"):
     assert out_tree.value.args[2].s == "msg"
 
 
-@test("get_assertion_message({src}) returns '{msg}'")
-def _(
-    src=each("assert 1 == 2, 'msg'", "assert 1 == 2", "assert 1 == 2, 1"),
-    msg=each(ast.Str("msg"), ast.Str(""), ast.Num(1)),
-):
-    in_tree: ast.Assert = ast.parse(src).body[0]
-    from_source = get_assertion_msg(in_tree)
-    assert as_dict(msg) == as_dict(from_source)
+for msg, expected in [
+    ("", ast.Str("")),
+    (", 'msg'", ast.Str("msg")),
+    (", 1", ast.Num(1)),
+    (", 1 + 1", ast.BinOp(ast.Num(1), ast.Add(), ast.Num(1))),
+]:
+
+    @test("get_assertion_message({src}) returns '{msg}'")
+    def _(msg=msg, expected=expected):
+        in_tree: ast.Assert = ast.parse(f"assert 1 == 2{msg}").body[0]
+        from_source = get_assertion_msg(in_tree)
+        assert as_dict(from_source) == as_dict(expected)
 
 
 @test("make_call_node converts `{src}` to correct function call node`")

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -111,10 +111,11 @@ def _(src="assert 1 == 2, 'msg'"):
 @test("get_assertion_message({src}) returns '{msg}'")
 def _(
     src=each("assert 1 == 2, 'msg'", "assert 1 == 2", "assert 1 == 2, 1"),
-    msg=each("msg", "", ""),
+    msg=each(ast.Constant("msg"), ast.Constant(""), ast.Constant(1)),
 ):
     in_tree = ast.parse(src).body[0]
-    assert msg == get_assertion_msg(in_tree)
+    from_source = get_assertion_msg(in_tree)
+    assert msg.value == from_source.value
 
 
 @test("make_call_node converts `{src}` to correct function call node`")

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,6 +1,5 @@
-from io import StringIO
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from rich.console import Console, RenderGroup
 from rich.padding import Padding
@@ -22,7 +21,6 @@ from ward._terminal import (
     get_exit_code,
     get_test_result_line,
     outcome_to_style,
-    theme,
 )
 from ward._testing import _Timer
 from ward.expect import Comparison, TestFailure
@@ -287,13 +285,8 @@ for outcome, expected_output in [
 
 
 @fixture
-def mock_rich_console() -> Console:
-    return Console(
-        file=StringIO(),
-        theme=theme,
-        force_terminal=True,
-        width=80,
-    )
+def mock_rich_console():
+    return Mock(spec=Console)
 
 
 @fixture

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -310,7 +310,7 @@ for left, right in [
     ({"a": "b"}, [1, 2, 3, 4]),
 ]:
 
-    @test("TestResultWriter.get_diff handles assert *==* failure")
+    @test("TestResultWriter.get_diff handles assert `==` failure")
     def _(lhs=left, rhs=right, writer=writer, console=mock_rich_console):
         failure = TestFailure("fail", lhs, rhs, 1, Comparison.Equals, "test")
         diff_render = writer.get_diff(failure)
@@ -327,7 +327,7 @@ for left, right in [
     ("a", {"b": 1}),
 ]:
 
-    @test("TestResultWriter.get_operands handles assert *in* failure")
+    @test("TestResultWriter.get_operands handles assert `in` failure")
     def _(lhs=left, rhs=right, writer=writer):
         failure = TestFailure("fail", lhs, rhs, 1, Comparison.In, "test")
         lhs_render, rhs_render = writer.get_operands(failure).renderables
@@ -345,9 +345,7 @@ for left, right in [
     ("a", {"a": 1}),
 ]:
 
-    @test(
-        "TestResultWriter.get_pretty_comparison_failure handles assert *not in* failure"
-    )
+    @test("TestResultWriter.get_operands handles assert `not in` failure")
     def _(lhs=left, rhs=right, writer=writer):
         failure = TestFailure("fail", lhs, rhs, 1, Comparison.NotIn, "test")
         lhs_render, rhs_render = writer.get_operands(failure).renderables
@@ -359,14 +357,35 @@ for left, right in [
         )
 
 
+for comparison, description in [
+    (Comparison.Equals, "not equal to"),
+    (Comparison.NotEquals, "equal to"),
+    (Comparison.LessThan, "less than"),
+    (Comparison.LessThanEqualTo, "less than or equal to"),
+    (Comparison.GreaterThan, "greater than"),
+    (Comparison.GreaterThanEqualTo, "greater than or equal to"),
+]:
+
+    @test(
+        "TestResultWriter.get_operands has a specialized description for `{comparison.value}`"
+    )
+    def _(writer=writer, comparison=comparison, description=description):
+        failure = TestFailure("fail", "a", "b", 1, comparison, "test")
+        lhs_render, rhs_render = writer.get_operands(failure).renderables
+
+        assert description in rhs_render.title.plain
+
+
 for comparison in Comparison:
 
-    @test("TestResultWriter.get_pretty_failure can handle {comparison.value} failures")
+    @test(
+        "TestResultWriter.get_pretty_comparison_failure can handle `{comparison.value}` failures"
+    )
     def _(comparison=comparison, writer=writer):
         failure = TestFailure("fail", "a", "b", 1, comparison, "test")
-        renderable = writer.get_pretty_failure(failure)
+        renderable = writer.get_pretty_comparison_failure(failure)
 
-        assert renderable
+        assert renderable is not None
 
 
 @test("TestResultWriter.output_all_test_results returns empty list if suite is empty")

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from rich.console import Console, RenderGroup
 from rich.padding import Padding
@@ -384,16 +384,14 @@ for comparison in Comparison:
 @test("TestResultWriter.output_all_test_results returns empty list if suite is empty")
 def _(console=mock_rich_console):
     suite = Suite([])
+    result_writer = TestResultWriter(
+        console=console,
+        suite=suite,
+        test_output_style=TestOutputStyle.TEST_PER_LINE,
+        progress_styles=[TestProgressStyle.INLINE],
+        config_path=None,
+    )
 
-    with patch.object(console, "print") as mock:
-        result_writer = TestResultWriter(
-            console=console,
-            suite=suite,
-            test_output_style=TestOutputStyle.TEST_PER_LINE,
-            progress_styles=[TestProgressStyle.INLINE],
-            config_path=None,
-        )
-
-        result = result_writer.output_all_test_results(_ for _ in ())
-        assert result == []
-        assert not mock.called
+    result = result_writer.output_all_test_results(_ for _ in ())
+    assert result == []
+    assert not console.print.called

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -375,7 +375,7 @@ for comparison in Comparison:
         "TestResultWriter.get_pretty_comparison_failure can handle `{comparison.value}` failures"
     )
     def _(comparison=comparison, writer=writer):
-        failure = TestFailure("fail", "a", "b", 1, comparison, "test")
+        failure = TestFailure("fail", "a", "b", 1, comparison, "")
         renderable = writer.get_pretty_comparison_failure(failure)
 
         assert renderable is not None

--- a/ward/_diff.py
+++ b/ward/_diff.py
@@ -9,11 +9,21 @@ from rich.text import Text
 class Diff:
     """Constructs a Diff object to render diff-highlighted code."""
 
-    def __init__(self, lhs, rhs, width, show_symbols=False) -> None:
+    def __init__(
+        self,
+        lhs: object,
+        rhs: object,
+        width: int,
+        show_symbols: bool = False,
+    ) -> None:
         self.width = width
         self.lhs = lhs if isinstance(lhs, str) else pprintpp.pformat(lhs, width=width)
         self.rhs = rhs if isinstance(rhs, str) else pprintpp.pformat(rhs, width=width)
         self.show_symbols = show_symbols
+
+    @property
+    def sides_are_different(self) -> bool:
+        return self.lhs != self.rhs
 
     def raw_unified_diff(self) -> Iterator[str]:
         differ = difflib.Differ()

--- a/ward/_rewrite.py
+++ b/ward/_rewrite.py
@@ -32,19 +32,17 @@ assert_func_namespace = {
 }
 
 
-def get_assertion_msg(node: ast.expr) -> str:
-    if node.msg and isinstance(node.msg, ast.Str):
-        msg = node.msg.s
+def get_assertion_msg(node: ast.expr):
+    if node.msg:
+        return node.msg
     else:
-        msg = ""
-    return msg
+        return ast.Str("")
 
 
 def make_call_node(node: ast.expr, func_name: str) -> ast.Expr:
-    msg = get_assertion_msg(node)
     call = ast.Call(
         func=ast.Name(id=func_name, ctx=ast.Load()),
-        args=[node.test.left, node.test.comparators[0], ast.Str(s=msg)],
+        args=[node.test.left, node.test.comparators[0], get_assertion_msg(node)],
         keywords=[],
     )
     new_node = ast.Expr(value=call)

--- a/ward/_rewrite.py
+++ b/ward/_rewrite.py
@@ -32,9 +32,9 @@ assert_func_namespace = {
 }
 
 
-def get_assertion_msg(node: ast.expr):
-    if node.msg:
-        return node.msg
+def get_assertion_msg(assertion: ast.Assert) -> ast.expr:
+    if assertion.msg:
+        return assertion.msg
     else:
         return ast.Str("")
 

--- a/ward/_terminal.py
+++ b/ward/_terminal.py
@@ -779,7 +779,7 @@ class TestResultWriter(TestResultWriterBase):
         if isinstance(err, TestFailure):
             if err.operator in Comparison:
                 self.console.print(self.get_source(err, test_result))
-                self.console.print(self.get_pretty_failure(err))
+                self.console.print(self.get_pretty_comparison_failure(err))
         else:
             self.print_traceback(err)
 
@@ -797,7 +797,7 @@ class TestResultWriter(TestResultWriterBase):
 
         return Padding(src, (1, 0, 1, 4))
 
-    def get_pretty_failure(self, err: TestFailure) -> RenderableType:
+    def get_pretty_comparison_failure(self, err: TestFailure) -> RenderableType:
         parts = [
             self.get_operands(err),
             self.get_diff(err),

--- a/ward/_terminal.py
+++ b/ward/_terminal.py
@@ -822,7 +822,7 @@ class TestResultWriter(TestResultWriterBase):
             self.get_assert_message(err),
         ]
         return Padding(
-            RenderGroup(*filter(None, parts)),
+            RenderGroup(*(part for part in parts if part)),
             pad=(0, 0, 1, 2),
         )
 
@@ -925,6 +925,7 @@ class TestResultWriter(TestResultWriterBase):
             )
             if diff.sides_are_different:
                 return diff
+        return None
 
     def get_diff(self, err: TestFailure) -> Optional[RenderableType]:
         diff = self._get_diff(err)

--- a/ward/_terminal.py
+++ b/ward/_terminal.py
@@ -866,8 +866,8 @@ class TestResultWriter(TestResultWriterBase):
                 ("id ", "default"),
                 (f"{id(err.rhs)}", "bold default"),
             )
-        else:
-            raise Exception("unknown operator")
+        else:  # pragma: unreachable
+            raise Exception(f"Unknown operator: {err.operator!r}")
 
         lhs = Panel(
             Pretty(err.lhs),

--- a/ward/expect.py
+++ b/ward/expect.py
@@ -57,23 +57,34 @@ class Comparison(Enum):
     GreaterThanEqualTo = ">="
 
 
+IN_COMPARISONS = {
+    Comparison.In,
+    Comparison.NotIn,
+}
+IS_COMPARISONS = {
+    Comparison.Is,
+    Comparison.IsNot,
+}
+EQUALITY_COMPARISONS = {
+    Comparison.Equals,
+    Comparison.NotEquals,
+}
+INEQUALITY_COMPARISONS = {
+    Comparison.LessThan,
+    Comparison.LessThanEqualTo,
+    Comparison.GreaterThan,
+    Comparison.GreaterThanEqualTo,
+}
+
+
 @dataclass
 class TestFailure(Exception):
-    def __init__(
-        self,
-        message: str,
-        lhs: Any,
-        rhs: Any,
-        error_line: int,
-        operator: Comparison,
-        assert_msg: str,
-    ):
-        self.lhs = lhs
-        self.rhs = rhs
-        self.message = message
-        self.error_line = error_line
-        self.operator = operator
-        self.assert_msg = assert_msg
+    message: str
+    lhs: Any
+    rhs: Any
+    error_line: int
+    operator: Comparison
+    assert_msg: str
 
 
 def assert_equal(lhs_val: Any, rhs_val: Any, assert_msg: str) -> None:


### PR DESCRIPTION
Following up on https://github.com/darrenburns/ward/pull/242 , this PR is a take on:
- Introducing pretty output for all comparison failures, in the same titled-panel style we landed on in the other PR.
- Introducing a consistent, extensible way to generate and combine parts of the comparison failure pretty output (it is very easy to add/change parts in the source, and should hopefully be easy to hookify it).
- Revising the existing `==` output to use the titled-panel style.

Incidentally, I extended the output to include assertion messages if present, and allowed for assertion messages that aren't plain strings.

Here's what it looks like right now on this example: [test_examples.txt](https://github.com/darrenburns/ward/files/6603434/test_examples.txt):

![image](https://user-images.githubusercontent.com/7133863/120908704-89f2fe80-c632-11eb-82af-516780e5030a.png)

I decided to make the two operands be displayed side-by-side to save vertical space on wide terminals. If the terminal is narrow, Rich will automatically stack them vertically instead!

![image](https://user-images.githubusercontent.com/7133863/120908832-1eaa2c00-c634-11eb-938c-4e2deae53bcf.png)
