### PR TITLE
Fix broken command 

### DIFF
--- a/docs/source/guide/running_tests.rst
+++ b/docs/source/guide/running_tests.rst
@@ -1,3 +1,5 @@
+.. _running_tests:
+
 Running Tests via the CLI
 =========================
 

--- a/docs/source/guide/writing_tests.rst
+++ b/docs/source/guide/writing_tests.rst
@@ -65,7 +65,7 @@ integration tests which target any mobile platform, you might invoke it like so:
 
 ``ward --tags "integration and (ios or android)"``
 
-For a deeper look into tag expressions, see the [running tests](/guide/running-tests) page.
+For a deeper look into tag expressions, see the :ref:`running tests<running_tests>` page.
 
 Using ``assert`` statements
 ---------------------------

--- a/ward/_run.py
+++ b/ward/_run.py
@@ -284,6 +284,7 @@ def test(
 def fixtures(
     ctx: click.Context,
     config: str,
+    project_root: Optional[Path],
     config_path: Optional[Path],
     path: Tuple[str],
     exclude: Tuple[str],
@@ -296,6 +297,7 @@ def fixtures(
     full: bool,
 ):
     """Show information on fixtures."""
+    configure_path(project_root)
     paths = [Path(p) for p in path]
     mod_infos = get_info_for_modules(paths, exclude)
     modules = list(load_modules(mod_infos))


### PR DESCRIPTION
- Fix `ward fixtures` command. It is broken.
```shell
(venv) $ ward fixtures
Traceback (most recent call last):
  File "C:\Python38\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Python38\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "D:\python\try_ward\venv\Scripts\ward.exe\__main__.py", line 7, in <module>
  File "d:\python\try_ward\venv\lib\site-packages\click\core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "d:\python\try_ward\venv\lib\site-packages\click\core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "d:\python\try_ward\venv\lib\site-packages\click\core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "d:\python\try_ward\venv\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "d:\python\try_ward\venv\lib\site-packages\click\core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "d:\python\try_ward\venv\lib\site-packages\click\decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
TypeError: fixtures() got an unexpected keyword argument 'project_root'
```
- Also, fix #250 