### PR TITLE
Allow subclasses of specified exception class to pass raises assertion

### DIFF
--- a/tests/test_expect.py
+++ b/tests/test_expect.py
@@ -69,6 +69,15 @@ def _():
         raise ValueError
 
 
+@test("ward.raises doesn't raise if the a base class of the error is raised")
+def _():
+    class SubClass(ValueError):
+        pass
+
+    with raises(ValueError):
+        raise SubClass()
+
+
 @test("ward.raises gives access to the raised error afterwards")
 def _():
     err = ValueError("x")

--- a/ward/expect.py
+++ b/ward/expect.py
@@ -36,7 +36,7 @@ class raises(Generic[_E], ContextManager["raises[_E]"]):
         exc_val: Optional[BaseException],
         exc_tb: Optional[types.TracebackType],
     ) -> bool:
-        if exc_type is not self.expected_ex_type:
+        if not issubclass(exc_type, self.expected_ex_type):
             raise AssertionError(
                 f"Expected exception {self.expected_ex_type}, but {exc_type} was raised instead."
             )


### PR DESCRIPTION
Currently `raises` only passes if the exact exception type is specified. 
However, sometimes an implementation can choose to raise a private subclass of a public exception class.