### PR TITLE
Type check `ward.testing`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ overrides = [
     { module = "click_completion.*", ignore_missing_imports = true },
     { module = "click_default_group.*", ignore_missing_imports = true },
     # TODO: Remove these lines and fix type-checker errors to gradually introduce mypy
-    { module = "ward.testing.*", ignore_errors = true },
     { module = "ward._rewrite.*", ignore_errors = true },
     { module = "ward._collect.*", ignore_errors = true },
     { module = "ward._run.*", ignore_errors = true },

--- a/ward/_terminal.py
+++ b/ward/_terminal.py
@@ -951,10 +951,13 @@ class TestResultWriter(TestResultWriterBase):
         if isinstance(test_result.error, TestFailure) or isinstance(
             test_result.error, AssertionError
         ):
+            # Ignore type checkers because `AssertionError` has the attribute
+            # `error_line` dynamically set.
+            error_line = test_result.error.error_line  # type: ignore[union-attr]
             self.console.print(
                 Padding(
                     Text(
-                        f"Failed at {os.path.relpath(test_result.test.path, Path.cwd())}:{test_result.error.error_line}"
+                        f"Failed at {os.path.relpath(test_result.test.path, Path.cwd())}:{error_line}"
                     ),
                     pad=(1, 0, 0, 2),
                 )


### PR DESCRIPTION
After this all of the public API is type checked so we may be ready to distribute type data.