### PR TITLE
Add entry_point to satisfy conda-build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[options.entry_points]
+console_scripts =
+    ward = ward._run:run
+
 [flake8]
 # black compatibility
 # https://github.com/psf/black/blob/main/docs/guides/using_black_with_other_tools.md#flake8


### PR DESCRIPTION
It seems that `conda-build` only looks at `setup.py` and `setup.cfg` for entry points. Therefore, [ward-feedstock](https://github.com/conda-forge/ward-feedstock/pull/10) fails to build `ward` for `conda-forge`.

This is documented [here](https://conda-forge.org/docs/maintainer/knowledge_base.html?highlight=entry_point):

> If `console_scripts` `entry_points` are defined in `setup.py` or `setup.cfg`, they are also listed in the build section of `meta.yaml`.