### PR TITLE
ci: change codecov upload from bash to codecov-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           poetry run coverage run -m ward
           poetry run coverage xml -i
 
-      - name: Upload coverage report to codecov
-        run: |
-          bash <(curl -s https://codecov.io/bash) -f coverage.xml
-        shell: bash
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true


### PR DESCRIPTION
Switch to Codecov GitHub action #245 

The simplest way to switch from bash script to **codecov GitHub avtions**.
When reviewing this PR, don't forget the [Codecov Uploader Deprecation Plan](https://about.codecov.io/blog/codecov-uploader-deprecation-plan/?ajs_uid=3169299&ajs_event=Clicked%20Email&mkt_tok=MzMyLUxWWC03NDEAAAGAGSaFnp9idItWfHc_FfI_9ATzIEGbDXw_zpIMwSnpY7JNm-93N20JVtZ48KnLyM96xnecM79hwC2zC3iYDtMMFh0l-OuuUo3ON4z5lT6L)