### PR TITLE
Add versions to mypy hook's additional dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,6 @@ repos:
         # Install type data of third-party dependencies
         additional_dependencies:
           - types-pkg_resources
-          - rich
-          - click
-          - tomli
+          - rich>=10.0.0,<11
+          - click>=7.0.0,<9
+          - tomli>=1.0.0,<2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,6 @@ repos:
         # Install type data of third-party dependencies
         additional_dependencies:
           - types-pkg_resources
-          - rich>=10.0.0,<11
+          - rich>=12.0.0,<13
           - click>=7.0.0,<9
-          - tomli>=1.0.0,<2
+          - tomli>=1.0.0,<3

--- a/poetry.lock
+++ b/poetry.lock
@@ -510,11 +510,11 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.3"
+version = "2.0.1"
 description = "A lil' TOML parser"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "typing-extensions"
@@ -539,7 +539,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.14.0"
+version = "20.14.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -571,7 +571,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.8"
-content-hash = "4b4ae476b27185fd21a908e5a464fac654cd9f6262365431016a615732ea1387"
+content-hash = "dd6be0026ef60a8911f96e01956bcefc1e83d275b62c3b283309af12374f60cf"
 
 [metadata.files]
 alabaster = [
@@ -871,8 +871,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
-    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
@@ -883,8 +883,8 @@ urllib3 = [
     {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.14.0-py2.py3-none-any.whl", hash = "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66"},
-    {file = "virtualenv-20.14.0.tar.gz", hash = "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"},
+    {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},
+    {file = "virtualenv-20.14.1.tar.gz", hash = "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"},
 ]
 zipp = [
     {file = "zipp-3.8.0-py3-none-any.whl", hash = "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ include = ["ward/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7.8"
-dataclasses = { version = ">=0.7,<0.9", python = "3.6" }
 click = ">=7,<9"
 rich = "^12.2.0"
 tomli = ">=1.0.0,<3.0.0"


### PR DESCRIPTION
I was recently introduced to Ward, and I really like the look and feel of it! I like to write my tests with mypy's [strict mode](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict), so I wanted to see if I could help with things like #261.

In the meantime, my freshly cloned copy of this repository would not pass `mypy` checking. Upon investigation, the project depends on `rich@^10.0.0`, but the pre-commit `mypy` hook was pulling down latest due to a lack of a version spec. Since `rich` had breaking changes between `10` and its current of `12`, type checking errors were triggered.

This little PR copies the version specs for non-stub typed dependencies from those specified in `pyproject.toml` over to the `additional_dependencies` section in `.pre-commit-config.yaml`, which should fix the issue and prevent it from happening again in the future.