### PR TITLE
Plugin config bug fix

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import click
 
-from tests.test_util import fake_project_pyproject
+from tests.test_util import fake_project_empty, fake_project_pyproject
 from ward import each, fixture, raises, test
 from ward._config import (
     apply_multi_defaults,
@@ -179,7 +179,7 @@ def _(project_root: Path = fake_project_pyproject):
         default_map={},
     )
     with mock.patch.object(Path, "cwd", return_value=project_root / "a" / "d"):
-        set_defaults_from_config(fake_context, None, None)  # type: ignore[arg-type]
+        assert set_defaults_from_config(fake_context, None, None) == fake_context.default_map  # type: ignore[arg-type]
 
     assert fake_context.default_map == {
         "exclude": (str(project_root / "a" / "b"),),
@@ -187,3 +187,21 @@ def _(project_root: Path = fake_project_pyproject):
         "order": "hello world",
     }
     assert fake_context.params["config_path"] == project_root / "pyproject.toml"
+
+
+@test(
+    "set_defaults_from_config returns {} if project_root does not contain pyproject.toml"
+)
+def _(project_root: Path = fake_project_empty):
+    """
+    This test checks the situation where we're currently
+    present in directory that has no pyproject.toml present
+    """
+    fake_context = types.SimpleNamespace(
+        params={"path": (str(project_root),)},
+        default_map={},
+    )
+    assert set_defaults_from_config(fake_context, None, None) == {}  # type: ignore[arg-type]
+
+    assert fake_context.params["project_root"] is None
+    assert fake_context.params["config_path"] is None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,4 @@
-from tests.utilities import make_project
+from tests.utilities import make_empty_project, make_project
 from ward import fixture, test, using
 from ward._utilities import find_project_root, group_by, truncate
 from ward.testing import each
@@ -32,6 +32,11 @@ def fake_project_pyproject():
     order = "hello world"
     """
     yield from make_project("pyproject.toml", content)
+
+
+@fixture
+def fake_project_empty():
+    yield from make_empty_project()
 
 
 @fixture

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -95,3 +95,19 @@ def make_project(root_file: str, file_content: str = ""):
         f.flush()
         yield (tempdir / "project").resolve()
     shutil.rmtree(tempdir / "project")
+
+
+def make_empty_project():
+    tempdir = Path(tempfile.gettempdir())
+    paths = [
+        tempdir / "project/a/b/c",
+        tempdir / "project/a/d",
+        tempdir / "project/a",
+        tempdir / "project/x/y/z",
+    ]
+    for path in paths:
+        path.mkdir(parents=True, exist_ok=True)
+
+    yield (tempdir / "project").resolve()
+
+    shutil.rmtree(tempdir / "project")

--- a/ward/_config.py
+++ b/ward/_config.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Iterable, Optional, Union
+from typing import Any, Dict, Iterable, Optional, Union
 
 import click
 import tomli
@@ -91,7 +91,7 @@ def set_defaults_from_config(
     context: click.Context,
     param: click.Parameter,
     value: Union[str, int],
-) -> Optional[Path]:
+) -> Dict[str, Any]:
     paths_supplied_via_cli = context.params.get("path")
 
     search_paths = paths_supplied_via_cli
@@ -107,7 +107,7 @@ def set_defaults_from_config(
     else:
         context.params["project_root"] = None
         context.params["config_path"] = None
-        return Path.cwd()
+        return {}
 
     file_config = read_config_toml(project_root, _CONFIG_FILE)
     validate_config_toml(file_config)

--- a/ward/_config.py
+++ b/ward/_config.py
@@ -136,4 +136,4 @@ def set_defaults_from_config(
 
     context.default_map.update(file_config)
 
-    return config_path
+    return context.default_map

--- a/ward/_run.py
+++ b/ward/_run.py
@@ -179,9 +179,12 @@ def test(
 ):
     """Run tests."""
     config_params = ctx.params.copy()
-    config_params.pop("config")
 
-    config = Config(**config_params, plugin_config=config_params.get("plugins", {}))
+    plugin_config = config_params["config"].get("plugins", {})
+
+    del config_params["config"]
+
+    config = Config(**config_params, plugin_config=plugin_config)
 
     test_output_style = TestOutputStyle(test_output_style)
     progress_styles = [TestProgressStyle(ps) for ps in progress_style]


### PR DESCRIPTION
This PR addresses the #330

Changes:
- `set_defaults_from_config` now returns the config instead of string location of the config file
- `test` command picks up plugin config before dropping the rest of config and passes it to config object
- `del` statement instead of `.pop` method to be more explicit about the intent
