### PR TITLE
When running in GitHub Actions, force colors on

### DIFF
--- a/ward/_terminal.py
+++ b/ward/_terminal.py
@@ -93,7 +93,10 @@ theme = Theme(
         "usedby": "#9285F6",
     }
 )
-rich_console = Console(theme=theme, highlighter=NullHighlighter())
+in_ci_supporting_color = os.environ.get("GITHUB_ACTIONS") == "true"
+rich_console = Console(
+    theme=theme, highlighter=NullHighlighter(), force_terminal=in_ci_supporting_color
+)
 
 
 def format_test_id(test_result: TestResult) -> str:


### PR DESCRIPTION
Fixes #243

Maybe the coloring can be improved from here, this is at least what I see, with this change:

![image](https://user-images.githubusercontent.com/1787385/191810559-ce28fc48-8a82-4316-a52a-daadbfb395c8.png)
