### PR TITLE
add max-frames option to limit traceback length

### DIFF
--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -295,7 +295,7 @@ def mock_rich_console():
 @fixture
 def writer(console=mock_rich_console):
     yield TestResultWriter(
-        console, Suite([]), TestOutputStyle.LIVE, [TestProgressStyle.INLINE], None
+        console, Suite([]), TestOutputStyle.LIVE, [TestProgressStyle.INLINE], None, 100
     )
 
 
@@ -393,6 +393,7 @@ def _(console=mock_rich_console):
         test_output_style=TestOutputStyle.TEST_PER_LINE,
         progress_styles=[TestProgressStyle.INLINE],
         config_path=None,
+        max_frames=100,
     )
 
     result = result_writer.output_all_test_results(_ for _ in ())

--- a/ward/_run.py
+++ b/ward/_run.py
@@ -127,6 +127,12 @@ hook_module = click.option(
     """,
 )
 @click.option(
+    "--max-frames",
+    type=int,
+    default=100,
+    help="The maximum number of stack frames to show in tracebacks.",
+)
+@click.option(
     "--order",
     type=click.Choice(["standard", "random"], case_sensitive=False),
     default="standard",
@@ -170,6 +176,7 @@ def test(
     fail_limit: Optional[int],
     test_output_style: str,
     progress_style: List[str],
+    max_frames: int,
     order: str,
     capture_output: bool,
     show_slowest: int,
@@ -227,6 +234,7 @@ def test(
         progress_styles=progress_styles,
         config_path=config_path,
         show_diff_symbols=show_diff_symbols,
+        max_frames=max_frames,
     )
     for renderable in print_before:
         rich_console.print(renderable)

--- a/ward/_terminal.py
+++ b/ward/_terminal.py
@@ -675,6 +675,7 @@ class TestResultWriterBase:
         test_output_style: TestOutputStyle,
         progress_styles: List[TestProgressStyle],
         config_path: Optional[Path],
+        max_frames: int,
         show_diff_symbols: bool = False,
     ):
         self.console = console
@@ -684,6 +685,7 @@ class TestResultWriterBase:
         self.config_path = config_path
         self.show_diff_symbols = show_diff_symbols
         self.terminal_size = get_terminal_size()
+        self.max_frames = max_frames
 
     def output_all_test_results(
         self,
@@ -951,7 +953,9 @@ class TestResultWriter(TestResultWriterBase):
             # The first frame contains library internal code which is not
             # relevant to end users, so skip over it.
             trace = trace.tb_next
-            tb = Traceback.from_exception(err.__class__, err, trace, show_locals=True)
+            tb = Traceback.from_exception(
+                err.__class__, err, trace, show_locals=True, max_frames=self.max_frames
+            )
             self.console.print(Padding(tb, pad=(0, 2, 1, 2)))
         else:
             self.console.print(str(err))

--- a/ward/config.py
+++ b/ward/config.py
@@ -27,3 +27,4 @@ class Config:
     hook_module: Tuple[str]
     progress_style: Tuple[str]
     plugin_config: Dict[str, Dict[str, Any]]
+    max_frames: int


### PR DESCRIPTION
this leverages rich's own functionality to limit the length of tracebacks to something more reasonable when using libraries such as sqlalchemy and fastapi that tend to have very deeply nested function calls.

this possibly assists with #338 