### PR TITLE
If FORCE_COLOR is set, tell rich to force_terminal

### DIFF
--- a/ward/_terminal.py
+++ b/ward/_terminal.py
@@ -93,7 +93,11 @@ theme = Theme(
         "usedby": "#9285F6",
     }
 )
-rich_console = Console(theme=theme, highlighter=NullHighlighter())
+rich_console = Console(
+    theme=theme,
+    highlighter=NullHighlighter(),
+    force_terminal=True if os.environ.get("FORCE_COLOR") else None,
+)
 
 
 def format_test_id(test_result: TestResult) -> str:


### PR DESCRIPTION
Another try for the case of #243, as an alternative to #345.

This uses rich's `force_terminal` option whenever `FORCE_COLOR` is set in the environment, and so applies to any CI system equally. The user is however required to go ahead and set `FORCE_COLOR` when they want it.