### PR TITLE
Only re-indent after rewriting asserts in Py <3.11

### DIFF
--- a/ward/_rewrite.py
+++ b/ward/_rewrite.py
@@ -1,5 +1,6 @@
 import ast
 import inspect
+import sys
 import textwrap
 import types
 from typing import Iterable, List
@@ -106,10 +107,11 @@ def rewrite_assertion(test: Test) -> Test:
 
     new_tree = RewriteAssert().visit(tree)
 
-    # We dedented the code so that it was a valid tree, now re-apply the indent
-    for child in ast.walk(new_tree):
-        if hasattr(child, "col_offset"):
-            child.col_offset = getattr(child, "col_offset", 0) + col_offset
+    if sys.version_info[:2] < (3, 11):
+        # We dedented the code so that it was a valid tree, now re-apply the indent
+        for child in ast.walk(new_tree):
+            if hasattr(child, "col_offset"):
+                child.col_offset = getattr(child, "col_offset", 0) + col_offset
 
     # Reconstruct the test function
     new_mod_code_obj = compile(new_tree, code_obj.co_filename, "exec")


### PR DESCRIPTION
I don't know if or why this makes sense, but it seems to get tests running and passing across Python versions, fixing #352.

Please have a look. Maybe there's a better change to make, but I hope this will be useful in the process of figuring that out.