### PR TITLE
Improve type hints on main functions

### DIFF
--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -52,7 +52,7 @@ def dependent_test():
     return Test(fn=_, module_name=mod)
 
 
-@fixture()
+@fixture
 def cache():
     return FixtureCache()
 

--- a/ward/_testing.py
+++ b/ward/_testing.py
@@ -16,7 +16,7 @@ COLLECTED_TESTS: Dict[Path, List[Callable]] = defaultdict(list)
 
 @dataclass
 class Each:
-    args: Tuple[Any]
+    args: Tuple[Any, ...]
 
     def __getitem__(self, args):
         return self.args[args]


### PR DESCRIPTION
Currently type information in API is not complete. It makes it hard to use the library with mypy's strict mode and Pyright.

Also see: https://github.com/darrenburns/ward/issues/261#issuecomment-1301968435