### PR TITLE
Fix .pre-commit-config.yaml isort version that broke rencently

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/asottile/yesqa


### PR DESCRIPTION
Updating pre-commit 's isort.

The current version raises this error when `make prep:`
```
          RuntimeError: The Poetry configuration is invalid:
            - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```

Solution is to update to version `5.12.0`
Related SO post: https://stackoverflow.com/a/75269701/8843585