### PR TITLE
Option to show/hide local variables output in test results #338

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/asottile/yesqa

--- a/ward/_run.py
+++ b/ward/_run.py
@@ -152,6 +152,11 @@ hook_module = click.option(
     default=0,
 )
 @click.option(
+    "--show-locals/--hide-locals",
+    help="Print all tests without executing them",
+    default=True,
+)
+@click.option(
     "--dry-run/--no-dry-run",
     help="Print all tests without executing them",
     default=False,
@@ -174,6 +179,7 @@ def test(
     capture_output: bool,
     show_slowest: int,
     show_diff_symbols: bool,
+    show_locals: bool,
     dry_run: bool,
     hook_module: Tuple[str],
 ):
@@ -227,6 +233,7 @@ def test(
         progress_styles=progress_styles,
         config_path=config_path,
         show_diff_symbols=show_diff_symbols,
+        show_locals=show_locals,
     )
     for renderable in print_before:
         rich_console.print(renderable)

--- a/ward/_terminal.py
+++ b/ward/_terminal.py
@@ -676,6 +676,7 @@ class TestResultWriterBase:
         progress_styles: List[TestProgressStyle],
         config_path: Optional[Path],
         show_diff_symbols: bool = False,
+        show_locals: bool = True,
     ):
         self.console = console
         self.suite = suite
@@ -683,6 +684,7 @@ class TestResultWriterBase:
         self.progress_styles = progress_styles
         self.config_path = config_path
         self.show_diff_symbols = show_diff_symbols
+        self.show_locals = show_locals
         self.terminal_size = get_terminal_size()
 
     def output_all_test_results(
@@ -951,7 +953,9 @@ class TestResultWriter(TestResultWriterBase):
             # The first frame contains library internal code which is not
             # relevant to end users, so skip over it.
             trace = trace.tb_next
-            tb = Traceback.from_exception(err.__class__, err, trace, show_locals=True)
+            tb = Traceback.from_exception(
+                err.__class__, err, trace, show_locals=self.show_locals
+            )
             self.console.print(Padding(tb, pad=(0, 2, 1, 2)))
         else:
             self.console.print(str(err))

--- a/ward/config.py
+++ b/ward/config.py
@@ -23,6 +23,7 @@ class Config:
     capture_output: bool
     show_slowest: int
     show_diff_symbols: bool
+    show_locals: bool
     dry_run: bool
     hook_module: Tuple[str]
     progress_style: Tuple[str]


### PR DESCRIPTION
### Usage
Showing: `ward --show-locals` or simply `ward` as it's the default option.
Hinding:  `ward --hide-locals`

_Image examples bellow._

### Motivation
Check #338 
But basically:
![image](https://user-images.githubusercontent.com/40267373/217983136-98076095-63bb-4744-bd61-6f076c7b3201.png)


### Examples

#### Showing locals

![image](https://user-images.githubusercontent.com/40267373/217981817-990dc834-1364-4a21-8665-c94373ba8b26.png)


#### Hiding locals

![image](https://user-images.githubusercontent.com/40267373/217981842-09f39c62-2ff7-444a-94ca-ee223d9c5ccf.png)
